### PR TITLE
Add ironfish reset to website

### DIFF
--- a/docs/onboarding/cli.md
+++ b/docs/onboarding/cli.md
@@ -53,6 +53,11 @@ To see live updates:
 ironfish status -f
 ```
 
+#### reset
+Deletes your chain and wallet state preserves your accounts. It will import your accounts afterwards into a fresh node state.
+```sh
+ironfish reset
+```
 
 ### Config
 #### config:show

--- a/docs/onboarding/cli.md
+++ b/docs/onboarding/cli.md
@@ -54,7 +54,7 @@ ironfish status -f
 ```
 
 #### reset
-Deletes your chain and wallet state preserves your accounts. It will import your accounts afterwards into a fresh node state.
+Deletes your chain and wallet state, but preserves your accounts. It will import your accounts afterwards into a fresh node state.
 ```sh
 ironfish reset
 ```


### PR DESCRIPTION
https://linear.app/ironfish/issue/IRO-613

This documents the ironfish reset command, which resets your node state but preserves your accounts. We'll need a page later documenting specifically how to reset your node in the event of a test-net reset, but we can do that later when we're ready for another phase.