### PR TITLE
Update Discord link to one with unlimited length

### DIFF
--- a/blog/2021-03-06-introducing-ironfish.md
+++ b/blog/2021-03-06-introducing-ironfish.md
@@ -15,7 +15,7 @@ tags: [history, name, native americans, ironfish]
 
 Today, Iron Fish enters its first public testnet phase—anyone (yes, you too!) can now [run and mine a full Iron Fish node](https://ironfish.network/docs/onboarding/iron-fish-tutorial). After roughly two years of building Iron Fish, I am so excited to share our vision with the world. Iron Fish is a privacy-first cryptocurrency that anyone can use, without compromising on privacy or usability.
 
-If you have feedback, questions, trouble running your node, or just want to drop in and say ‘hi’, please join us in [Discord](https://discord.com/invite/H7Mk3qacyM).
+If you have feedback, questions, trouble running your node, or just want to drop in and say ‘hi’, please join us in [Discord](https://discord.gg/EkQkEcm8DH).
 
 Many angels and organizations have helped us get here, and we’re thankful for the funding we’ve raised to date ($5.3M) from Electric Capital (Avichal Garg), Elad Gil, Metastable (Naval Ravikant and Lucas Ryan), A Capital (Kartik Talwar), Slow Ventures (Jill Carlson), Dylan Field (Figma), John Lilly, Jack Abraham (Atomic), Juan Benet (Filecoin), Jack Chou, Balaji Srinivasan, Lemniscap (Roderik van der Graaf), James Prestwich, and Linda Xie. We are honored to work with such amazing people.
 
@@ -35,11 +35,11 @@ In 2021 it is apparent that people’s relationship with privacy is changing. Si
 
 As cash continues to disappear, crypto will only become a viable alternative to traditional banking if we truly embrace privacy.
 
-Interested in participating? Check out our [Discord](https://discord.com/invite/H7Mk3qacyM) on how to get started with Iron Fish today and for future announcements, as well as our [careers page](https://ironfish.network/careers/) for full-time positions. Incentivized testnet will be announced at a future date.
+Interested in participating? Check out our [Discord](https://discord.gg/EkQkEcm8DH) on how to get started with Iron Fish today and for future announcements, as well as our [careers page](https://ironfish.network/careers/) for full-time positions. Incentivized testnet will be announced at a future date.
 
 See you on the Iron Fish network!
 
 📚 Tutorial: https://ironfish.network/docs/onboarding/iron-fish-tutorial  
-🎤 Discord: https://discord.gg/kpKeGkA3  
+🎤 Discord: https://discord.gg/EkQkEcm8DH  
 🐦 Twitter: https://twitter.com/ironfishcrypto  
 📢 Telegram: https://t.me/ironfishcryptochat

--- a/docs/onboarding/mine.md
+++ b/docs/onboarding/mine.md
@@ -8,7 +8,7 @@ hide_table_of_contents: false
 
 Miners are essential to the health of the Iron Fish network. Without them, blocks won't be generated and transactions won't be transmitted. Iron Fish is still at the testnet stage.
 
-In the future, we plan to offer incentives for users to mine blocks on the testnet. Join our [Discord](https://discord.gg/kpKeGkA3) to stay up-to-date with our upcoming announcements!
+In the future, we plan to offer incentives for users to mine blocks on the testnet. Join our [Discord](https://discord.gg/EkQkEcm8DH) to stay up-to-date with our upcoming announcements!
 
 ## Requirements
 Install Iron Fish by following the instructions [here](onboarding/installation.md).
@@ -44,7 +44,7 @@ ironfish config:set blockGraffiti "<your graffiti here>"
 ```
 
 ## Join a mining pool
-$IRON is not available on a mining pool at the moment. [Join our Discord](https://discord.gg/kpKeGkA3) if you're interested in creating a pool for Iron Fish.
+$IRON is not available on a mining pool at the moment. [Join our Discord](https://discord.gg/EkQkEcm8DH) if you're interested in creating a pool for Iron Fish.
 
 ## Troubleshooting
 

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -139,7 +139,7 @@ function Footer() {
                 alt="Twitter"
               />
             </a>
-            <a href="https://discord.gg/kpKeGkA3">
+            <a href="https://discord.gg/EkQkEcm8DH">
               <img
                 src="/img/footer/discord.svg"
                 width="15"


### PR DESCRIPTION
The Discord link was set to expire after a week and pointed at the wrong channel. Updated to one that points to #announcements.

Fixes IRO-632
