### PR TITLE
Disable dependabot from opening PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     labels:
       - dependencies


### PR DESCRIPTION
We can view security notices in the Security tab, and sometimes have had these updates break the site, so let's turn these off for now.
