### PR TITLE
Fix navbar link appearance on WebKit

### DIFF
--- a/src/theme/Navbar/Button.js
+++ b/src/theme/Navbar/Button.js
@@ -12,7 +12,7 @@ export const RawButton = ({
     <button
       className={`
         ${overrides.rawButton}
-        flex 
+        flex
         justify-center
         items-center
         font-extended

--- a/src/theme/Navbar/Links.js
+++ b/src/theme/Navbar/Links.js
@@ -33,8 +33,8 @@ export function NavbarLinks({
 
   return (
     <>
-    <a className={linkClass} href="/docs/onboarding/iron-fish-tutorial">Get Started</a>
-    <a className={linkClass} href="/docs/whitepaper/1_introduction">Whitepaper</a>
+      <a className={linkClass} href="/docs/onboarding/iron-fish-tutorial">Get Started</a>
+      <a className={linkClass} href="/docs/whitepaper/1_introduction">Whitepaper</a>
       <SubnavButton
         label="Company"
         {...buttonStyles}

--- a/src/theme/Navbar/overrides.module.css
+++ b/src/theme/Navbar/overrides.module.css
@@ -30,7 +30,6 @@
   margin: 0;
   overflow: visible;
   text-transform: none;
-  -webkit-appearance: button;
   border-style: none;
 }
 


### PR DESCRIPTION
There's an issue with how navbar links are being displayed on WebKit browsers (i.e. Safari).

There are a few other unrelated WebKit styling issues that are not addressed in this PR, like the height of the navbar being incorrect.

| Before | After |
|-|-|
|<img width="1434" alt="CleanShot 2021-12-08 at 19 29 26@2x" src="https://user-images.githubusercontent.com/15393239/145312640-34933600-2e1a-42fe-9862-7a85e9917423.png">|<img width="1435" alt="CleanShot 2021-12-08 at 19 29 44@2x" src="https://user-images.githubusercontent.com/15393239/145312658-b838a793-707b-41e9-b74b-a121f4f4e638.png">|
