### PR TITLE
docs: update mining docs with incentivized testnet

### DIFF
--- a/docs/onboarding/mine.md
+++ b/docs/onboarding/mine.md
@@ -8,7 +8,7 @@ hide_table_of_contents: false
 
 Miners are essential to the health of the Iron Fish network. Without them, blocks won't be generated and transactions won't be transmitted. Iron Fish is still at the testnet stage.
 
-In the future, we plan to offer incentives for users to mine blocks on the testnet. Join our [Discord](https://discord.gg/EkQkEcm8DH) to stay up-to-date with our upcoming announcements!
+We are currently running an incentivised testnet where actively mining automatically earns you points for blocks that are mined and accepted to the main chain. To participate, visit our [testnet](https://testnet.ironfish.network/) website to learn more.
 
 ## Requirements
 Install Iron Fish by following the instructions [here](onboarding/installation.md).

--- a/docs/onboarding/mine.md
+++ b/docs/onboarding/mine.md
@@ -8,7 +8,7 @@ hide_table_of_contents: false
 
 Miners are essential to the health of the Iron Fish network. Without them, blocks won't be generated and transactions won't be transmitted. Iron Fish is still at the testnet stage.
 
-We are currently running an incentivised testnet where actively mining automatically earns you points for blocks that are mined and accepted to the main chain. To participate, visit our [testnet](https://testnet.ironfish.network/) website to learn more.
+We are currently running an incentivized testnet where actively mining automatically earns you points for blocks that are mined and accepted to the main chain. To participate, visit our [testnet](https://testnet.ironfish.network/) website to learn more.
 
 ## Requirements
 Install Iron Fish by following the instructions [here](onboarding/installation.md).


### PR DESCRIPTION
## Summary

Documentation on the incentivized testnet in this section are stale. I noticed the the mining docs referenced an upcoming incentivized testnet however, it's currently active. I've updated the docs to point to the testnet website.

## Testing Plan

No tests required.

## Breaking Change
```
- [] Yes
- [x] No
```
