### PR TITLE
Document the minerBatchSize config option

### DIFF
--- a/docs/onboarding/configuration.md
+++ b/docs/onboarding/configuration.md
@@ -52,6 +52,7 @@ You can change the working directory by passing the flag `--datadir` when runnin
 | logPrefix            | String to be prefixed to all logs. If any of the following strings are included, will replace them with the corresponding value: `%time%`, `%level%`, `%tag%` |
 | maxPeers             | The maximum number of peers to which the node can be connected at a time |
 | minPeers             | The minimum number of peers to which the node should be connected at any time |
+| minerBatchSize       | The number of hashes processed by miner per worker request |
 | miningForce          | Force mining |
 | nodeName             | Name of the node to be broadcasted to peers (optional) |
 | nodeWorkers          | The number of threads to use for workers. A value of -1 will use the maximum possible amount of threads.


### PR DESCRIPTION
## Summary

The `minerBatchSize` setting is not documented in the docs. I found it by luck when reading the code, but tuning it can improve the hash rate.

For example, for 1 x AMD EPYC 7402P 24-Core Processor @ 2.8GHz 64GB RAM, with the default batch size value that is equal to 10000, the hashrate is about 95M. However when increasing the batch size to 50000, the hash rate becomes 107M (further value increase doesn't improve perfomance).

I think it would be good to make people aware of this configuration and add it to the documentation that this PR does.

## Testing Plan

no testing. It is a documentation change

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

not a breaking change

gaffiti: chaoslab.network