### PR TITLE
Remind users to set graffiti, other doc updates

### DIFF
--- a/docs/onboarding/cli.md
+++ b/docs/onboarding/cli.md
@@ -100,8 +100,16 @@ config:get enableMiningDirector
 #### miners:start
 Starts a miner and subscribe to new blocks for the node. The node has to be synced with the network for the miner to start mining.
 
+**Note:** A valid graffiti is required in order to get credit for mining blocks in the incentivized testnet. Sign up for the incentivized testnet [here](https://testnet.ironfish.network/signup).
+
 ```sh
 ironfish miners:start
+```
+
+You can enable multiple threads by using the `-t` option with a value for the number of threads you wish to use. A value of -1 will use all available threads on the CPU. Try changing the number of threads to determine the best performance on your system.
+
+```sh
+ironfish miners:start -t -1
 ```
 
 #### miners:mined

--- a/docs/onboarding/cli.md
+++ b/docs/onboarding/cli.md
@@ -20,6 +20,29 @@ E.g. for a command:
 ironfish ironfish accounts:pay help
 ```
 
+### Testnet
+#### testnet
+Retrieves your user ID from the testnet servers to configure node name and graffiti.
+Requires an account with the incentivized testnet [here](https://testnet.ironfish.network/signup).
+
+```sh
+ironfish testnet
+
+Enter the user id or url to a testnet user like https://testnet.ironfish.network/users/1080
+User ID or URL: https://testnet.ironfish.network/users/1080
+
+Asking Iron Fish who user 1080 is...
+
+Hello JASON💪💎🚀!
+
+You are about to change your NODE NAME from testnet to JASON💪💎🚀
+You are about to change your GRAFFITI from testnet to JASON💪💎🚀
+Are you SURE? (y)es / (n)o: y
+
+✅ Updated NODE NAME from testnet to JASON💪💎🚀
+✅ Updated GRAFFITI from testnet to JASON💪💎🚀
+```
+
 ### Node
 #### start
 Starts the full node
@@ -100,7 +123,7 @@ config:get enableMiningDirector
 #### miners:start
 Starts a miner and subscribe to new blocks for the node. The node has to be synced with the network for the miner to start mining.
 
-**Note:** A valid graffiti is required in order to get credit for mining blocks in the incentivized testnet. Sign up for the incentivized testnet [here](https://testnet.ironfish.network/signup).
+**Note:** A valid graffiti is required in order to get credit for mining blocks in the incentivized testnet. Sign up for the incentivized testnet [here](https://testnet.ironfish.network/signup). Then run the [testnet](cli.md#testnet-1) command to set up your node's graffiti.
 
 ```sh
 ironfish miners:start

--- a/docs/onboarding/faucet.md
+++ b/docs/onboarding/faucet.md
@@ -21,7 +21,7 @@ ironfish faucet
 <Terminal command={Faucet} />
 <br />
 
-Once the request is executed, our Faucet will send a transaction to your account. Depending on the volume of requests, it might take several minutes before the coins reaches your account. You can check your balance with the following command:
+Once the request is executed, our Faucet will send a small transaction (10 $ORE) to your account. Depending on the volume of requests, it might take several minutes before the coins reaches your account. You can check your balance with the following command:
 ```sh
 ironfish accounts:balance
 ```

--- a/docs/onboarding/installation.md
+++ b/docs/onboarding/installation.md
@@ -67,6 +67,8 @@ docker run --rm --tty --interactive --network host --volume <home-directory>/.ir
 
 To run a miner replace `<threads>` with a number of threads to use for workers.
 
+**Note:** A valid graffiti is required to receive credit for mining blocks in the incentivized testnet.
+
 ```sh
 docker run --rm --tty --interactive --network host --volume <home-directory>/.ironfish:/root/.ironfish ghcr.io/iron-fish/ironfish:latest miners:start --threads=<threads>
 ```

--- a/docs/onboarding/mine.md
+++ b/docs/onboarding/mine.md
@@ -13,6 +13,8 @@ We are currently running an incentivized testnet where actively mining automatic
 ## Requirements
 Install Iron Fish by following the instructions [here](onboarding/installation.md).
 
+To receive credit for mining blocks, sign up for the incentivized testnet [here](https://testnet.ironfish.network/signup) to ensure your graffiti is unique when you set it.
+
 ## Quick start
 Start your node by running the following command:
 ```sh
@@ -35,13 +37,17 @@ And then set it up as default:
 ironfish accounts:use newAccount
 ```
 
-## Set block graffiti (optional)
+## Set block graffiti (required for testnet credit)
 
-Iron Fish blocks contain a 32-byte publicly-visible field called `graffiti` that can be set by the block's miner. To set this value to a UTF-8 encoded string on the blocks you mine, update the `blockGraffiti` config option:
+Iron Fish blocks contain a 32-byte publicly-visible field called `graffiti` that can be set by the block's miner. This is required by the incentivized testnet to give credit for mining blocks.
+
+To set this value to a UTF-8 encoded string on the blocks you mine, update the `blockGraffiti` config option:
 
 ```sh
 ironfish config:set blockGraffiti "<your graffiti here>"
 ```
+
+This command would set your graffiti to `<your graffiti here>`.
 
 ## Join a mining pool
 $IRON is not available on a mining pool at the moment. [Join our Discord](https://discord.gg/EkQkEcm8DH) if you're interested in creating a pool for Iron Fish.
@@ -52,6 +58,19 @@ $IRON is not available on a mining pool at the moment. [Join our Discord](https:
 - Difficulty (and therefore time to mine a block) can change depending on how fast blocks are mined on the Iron Fish network.
 - Make sure you are correctly connected to the Iron Fish network (you should see `Connected to the Iron Fish network` in your node logs).
 
+```sh
+Version       0.1.20 @ src
+Node Name     ...
+Graffiti      ...
+Peer Identity ...
+Peer Agent    if/cli/src
+Peer Port     9033
+Bootstrap     test.bn1.ironfish.network
+
+WebSocket server started at :::9033
+Connected to the Iron Fish network
+```
+
 #### Not connected to a node - waiting 5s before retrying
 Make sure that your node is currently running. If you are using a different `datadir` argument to start your node, make sure to use it as well when starting the miner. For example:
 
@@ -60,4 +79,4 @@ ironfish miners:start --datadir=~./ironfish2/
 ```
 
 #### The trees aren't the same size as the chain
-- Make sure your node is synced with the network before starting the miner. Run `ironfish status` to check if your node is still syncing.
+- Make sure your node is synced with the network before starting the miner. Run `ironfish status` to check if your node is still syncing. Refer to the command output [here](onboarding/health_node.md).

--- a/docs/onboarding/mine.md
+++ b/docs/onboarding/mine.md
@@ -13,18 +13,31 @@ We are currently running an incentivized testnet where actively mining automatic
 ## Requirements
 Install Iron Fish by following the instructions [here](onboarding/installation.md).
 
-**IMPORTANT:** To receive credit for mining blocks, sign up for the incentivized testnet [here](https://testnet.ironfish.network/signup) to ensure your graffiti is unique when you set it.
+A valid graffiti is required to receive credit for mining blocks in the incentivized testnet.
 
-## Quick start
+## Start Mining
 Start your node by running the following command:
 ```sh
 ironfish start
 ```
 
-Open a new terminal window and run:
+Sign up for the incentivized testnet [here](https://testnet.ironfish.network/signup).
+
+Open a new terminal window.
+
+If this is your first time mining set your graffiti and node name by running:
+
+```sh
+ironfish testnet
+```
+
+Followed by:
+
 ```sh
 ironfish miners:start
 ```
+
+Mining will not start until your node is synced to the head of the chain, which may take some time.
 
 ## Changing the default account
 If you want to use a different account to store the miners fee, you can create a new account by running the following command:

--- a/docs/onboarding/mine.md
+++ b/docs/onboarding/mine.md
@@ -1,5 +1,5 @@
 ---
-id: miner-iron-fish
+id: mine-iron-fish
 title: Mine Iron Fish
 sidebar_label: Mine Iron Fish
 description: Iron Fish mining | Iron Fish Onboarding
@@ -13,7 +13,7 @@ We are currently running an incentivized testnet where actively mining automatic
 ## Requirements
 Install Iron Fish by following the instructions [here](onboarding/installation.md).
 
-To receive credit for mining blocks, sign up for the incentivized testnet [here](https://testnet.ironfish.network/signup) to ensure your graffiti is unique when you set it.
+**IMPORTANT:** To receive credit for mining blocks, sign up for the incentivized testnet [here](https://testnet.ironfish.network/signup) to ensure your graffiti is unique when you set it.
 
 ## Quick start
 Start your node by running the following command:

--- a/docs/onboarding/new_account.md
+++ b/docs/onboarding/new_account.md
@@ -27,5 +27,7 @@ ironfish accounts:use MyNewAccount
 
 ## Next steps
 
-You can read about the different accounts commands on [this section](accounts.md).
 Now that you have created an account, you can use it to get coins or start mining.
+Read about the different accounts commands on [this section](accounts.md).
+
+Want to help grow Iron Fish? Join the incentivized testnet [here](https://testnet.ironfish.network/signup)!

--- a/docs/onboarding/new_node.md
+++ b/docs/onboarding/new_node.md
@@ -47,4 +47,8 @@ ironfish start --port=9045
 
 ## Next steps
 
-The node will now sync your local chain with the network. It might take a while for the full sync to be complete. But you can still use the node in the meantime.
+The node will now sync your local chain with the network.
+
+It might take a while for the full sync to be complete. You can check the progress with `ironfish status`. Refer to the command output [here](onboarding/health_node.md).
+
+Although you cannot mine blocks while a node is not synced to the head of the chain, other commands can be used during this time.

--- a/docs/onboarding/quick_start.md
+++ b/docs/onboarding/quick_start.md
@@ -1,0 +1,27 @@
+---
+id: iron-fish-quick-start
+title: Iron Fish Quick Start
+sidebar_label: Quick Start
+description: Quick Start | Iron Fish Onboarding
+hide_table_of_contents: true
+---
+
+Once installation is complete, start your node by running the following command:
+```sh
+ironfish start
+```
+
+Your node will attempt to connect to the Iron Fish testnet and begin to sync the blockchain.
+
+Next, sign up for the incentivized testnet [here](https://testnet.ironfish.network/signup).
+
+Open a new terminal window.
+
+Set your graffiti and node name from your testnet account by running:
+
+```sh
+ironfish testnet
+```
+
+## Next steps
+Now that your graffiti is set up, you can start mining or explore the other CLI commands.

--- a/sidebars.js
+++ b/sidebars.js
@@ -13,6 +13,7 @@ module.exports = {
   onboarding: [
     'onboarding/iron-fish-tutorial',
     'onboarding/installation-iron-fish',
+    'onboarding/iron-fish-quick-start',
     'onboarding/start-an-iron-fish-node',
     'onboarding/new-account-iron-fish',
     'onboarding/iron-fish-faucet',

--- a/sidebars.js
+++ b/sidebars.js
@@ -18,7 +18,7 @@ module.exports = {
     'onboarding/iron-fish-faucet',
     'onboarding/send-receive-iron-fish-transactions',
     'onboarding/iron-fish-explorer',
-    'onboarding/miner-iron-fish',
+    'onboarding/mine-iron-fish',
     'onboarding/iron-fish-node-health',
     'onboarding/iron-fish-configuration',
     'onboarding/iron-fish-accounts-commands',

--- a/src/theme/Navbar/Testnet.js
+++ b/src/theme/Navbar/Testnet.js
@@ -43,7 +43,7 @@ function Testnet({ condensed = false }) {
                   machine.
                 </p>
                 <a
-                  href="https://ironfish.network/docs/onboarding/iron-fish-tutorial"
+                  href="/docs/onboarding/iron-fish-tutorial"
                   className={`flex font-favorit text-sm ${overrides.link}`}
                 >
                   <span>Read the walkthrough</span>

--- a/src/theme/components/QuickLinks.js
+++ b/src/theme/components/QuickLinks.js
@@ -36,7 +36,7 @@ function QuickLinks() {
         icon="spin"
       />
       <QuickLink
-        link="/docs/onboarding/miner-iron-fish"
+        link="/docs/onboarding/mine-iron-fish"
         title="Mine $IRON"
         seeMore="Get to work"
         icon="block"


### PR DESCRIPTION
Documentation updates:
Remind new users set graffiti before mining.
Add -t option to miners:start command.
Add more details for some of the troubleshooting items.
Add encouragement to join testnet.
Add amount the Faucet sends.

## Summary
I've noticed several users ask about how they're not getting mining points. Turns out they didn't have a graffiti set.
Others reported why they're not mining. (They're not fully synced.)

Hopefully these changes will reduce the number of queries on Discord and improve the onboarding process.

## Testing Plan
Looked at the updated pages on localhost.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
