### PR TITLE
Fix typo in onboarding docs

### DIFF
--- a/docs/onboarding/new_node.md
+++ b/docs/onboarding/new_node.md
@@ -38,7 +38,7 @@ ironfish start --bootstrap=localhost:9031
 ```
 
 ## Using a different port
-By default, Iron Fish runs on port 9033. If you wishes to use a different port, you can use the `--port` flag.
+By default, Iron Fish runs on port 9033. If you wish to use a different port, you can use the `--port` flag.
 
 E.g.
 ```sh


### PR DESCRIPTION
## Summary

This PR fixes a little typo which I spotted while reading the docs. It is not a big deal and doesn't change meaning, but docs might look cleaner without it.

## Testing Plan

No need.

## Breaking Change

No.