### PR TITLE
Rename chain:block to blocks:show in documentation

### DIFF
--- a/docs/onboarding/cli.md
+++ b/docs/onboarding/cli.md
@@ -207,6 +207,13 @@ Shows the heaviest head and tail of the node's chain. Includes the last ten bloc
 ironfish chain:show
 ```
 
+### Blocks
+#### blocks:show
+Show the block header of a requested hash
+```sh
+ironfish blocks:show [HASH]
+```
+
 ### Workers
 #### workers:status
 Shows the status of the worker pool

--- a/docs/onboarding/cli.md
+++ b/docs/onboarding/cli.md
@@ -183,12 +183,6 @@ ironfish faucet
 ```
 
 ### Chain
-#### chain:block
-Show the block header of a requested hash
-```sh
-ironfish chain:block
-```
-
 #### chain:export
 Export a part of the chain database to JSON
 ```sh


### PR DESCRIPTION
## Summary
Fix #976 by removing command from CLI documentation.

## Testing Plan
Ran the local website. The chain:block command is removed.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
