### PR TITLE
Fix markup on whitepaper transactions

### DIFF
--- a/docs/whitepaper/6_transaction.md
+++ b/docs/whitepaper/6_transaction.md
@@ -157,15 +157,15 @@ In summary, the proof checks:
 
 - Check that the Merkle path is valid from the given merkle root to the leaf (that this note exists in a given tree)
 
-  3.**Value Commitment**
+3. **Value Commitment**
 
 - Check that the value commitment (**cv**) was indeed constructed as $$cv == v * G_v + rcv * G_{rcv}$$
 
-  4.**Nullifier**
+4. **Nullifier**
 
 - Check that the nullifier is derived from nk (the owner’s nullifier deriving key), the **cm** (note commitment) and **position**
 
-  5.**Random Authorization Key**
+5. **Random Authorization Key**
 
 - Check that the random authorization key (**rk**) that is used to sign the transaction is correctly derived from the spend authorization key (**ak**) and alpha (**α**) for randomness.
 


### PR DESCRIPTION
## Summary

Before:
![CleanShot 2022-05-25 at 07 38 04](https://user-images.githubusercontent.com/18919/170288697-ff416a10-b078-4793-b38a-713ce050345c.png)
After:
![CleanShot 2022-05-25 at 07 39 52](https://user-images.githubusercontent.com/18919/170289071-bb415cb8-f758-418e-b95c-39c1e792e8ba.png)

## Testing Plan

👀 

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] Nope
```
