### PR TITLE
adds documentation of chain:download to new_node and cli docs

### DIFF
--- a/docs/onboarding/cli.md
+++ b/docs/onboarding/cli.md
@@ -251,6 +251,12 @@ ironfish chain:show [START] [STOP]
 ```
 Optional arguments: [START] and [STOP] are either positive numbers that indicate the starting and stopping blocks or are negative to count backwards from the head of the chain.
 
+#### chain:download
+Downloads and imports a snapshot of the chain database
+```sh
+ironfish chain:download
+```
+
 ### Blocks
 #### blocks:show
 Show the block header of a requested hash

--- a/docs/onboarding/new_node.md
+++ b/docs/onboarding/new_node.md
@@ -48,3 +48,11 @@ ironfish start --port=9045
 ## Next steps
 
 The node will now sync your local chain with the network. It might take a while for the full sync to be complete. But you can still use the node in the meantime.
+
+## Downloading a chain snapshot
+
+To sync your local chain with the network more quickly you can download a snapshot of the chain database.
+
+```sh
+ironfish chain:download
+```


### PR DESCRIPTION
## Summary

Adds mentions of `chain:download` to 'new_node' page that cover starting up a new node and 'cli' page listing commands.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
