### PR TITLE
Fixed: Footer logo opening ironfish website in a new tab, when it shouldn't

### DIFF
--- a/docs/onboarding/installation.md
+++ b/docs/onboarding/installation.md
@@ -35,7 +35,7 @@ When new versions are announced, you can update through NPM:
 npm update -g ironfish
 ```
 
-Iron Fish is now ready to use. Follow the [next step](new_node.md) of the tutorial or jump directly to the [the CLI commands list](cli.md).
+Iron Fish is now ready to use. Follow the [next step](new_node.md) of the tutorial or jump directly to the [CLI commands list](cli.md).
 
 ## Alternative Installation Methods
 

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -47,7 +47,7 @@ function Footer() {
       <div className={classes.root}>
         <div className={classes.container}>
           <div className={classes.about}>
-            <Link to="https://www.ironfish.network">
+            <Link to="https://www.ironfish.network" target="_self">
               <img
                 src="/img/logo.svg"
                 alt="Iron Fish index"


### PR DESCRIPTION
## Summary
The footer logo used to opens the iron fish website in a new tab, when it shouldn't have. This PR changed the ironfish footer logo to open the ironfish website in the same tab.

Fixes: https://github.com/iron-fish/website/issues/193

Below is an image of the footer with the ironfish logo, where the issue was:
<img width="1440" alt="184707702-72b495f4-7a30-4f8b-a529-7356dae1d700" src="https://user-images.githubusercontent.com/92462002/184978629-1663d12e-385f-4650-94f5-01ef0ab22e7d.png">


## Testing Plan
Tested successfully

## Breaking Change
Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.
No
```
[ ] Yes
```
