### PR TITLE
Center newsletter signup alert message

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -189,6 +189,8 @@ input[type="email"] {
 }
 .msg-alert {
   position: absolute;
+  width: 410px;
+  text-align: center;
 }
 .pagination-nav {
   padding-top: 10px;
@@ -508,6 +510,9 @@ div.item {
     right: var(--ifm-navbar--toggle-right);
     color: var(--ifm-navbar-link-color);
   }
+  .msg-alert {
+    width: 290px;
+  }
 }
 @media screen and (max-width: 999px) {
   :root {
@@ -549,6 +554,7 @@ div.item {
     position: absolute;
     left: 0px;
     width: 100%;
+    text-align: center;
   }
 }
 @media screen and (max-width: 400px) {


### PR DESCRIPTION
## Summary
This PR centers the newsletter signup alert message

Fixes: https://github.com/iron-fish/website/issues/197
## Testing Plan
Before: 
<img width="1439" alt="185189526-68c9d0b2-425e-4879-825b-dc442eec81a9" src="https://user-images.githubusercontent.com/92462002/186994149-a026827b-36e4-4970-81a4-14b21a9bfeda.png">

After:
<img width="1440" alt="Screen Shot 2022-08-27 at 2 35 53 AM" src="https://user-images.githubusercontent.com/92462002/186994223-2b776680-9d6e-49bd-92ed-cdddf5a1af63.png">


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.
No
```
[ ] Yes
```
