### PR TITLE
Fix blog posts heading blending in

### DIFF
--- a/src/theme/BlogListPage/styles.module.css
+++ b/src/theme/BlogListPage/styles.module.css
@@ -112,6 +112,10 @@
     --ifm-featured-align-item: center;
     --ifm-featured-image-margin-top: var(--ifm-small-vertical-padding);
   }
+  .listPosts .post p {
+    font-size: 2.5vw;
+    padding: 1em;
+  }
 }
 @media screen and (max-width: 1050px) {
   :root {
@@ -132,5 +136,9 @@
     --ifm-featured-h1-font-size: 45px;
     --ifm-featured-h1-line-height: 54px;
     --ifm-featured-vertical-padding: var(--ifm-small-vertical-padding);
+  }
+  .listPosts .post p {
+    font-size: 5vw;
+    padding: 0.5em;
   }
 }


### PR DESCRIPTION
## Summary
On smaller screens the blog posts heading text start to blend in with the photo, and this PR makes it responsive.

Fixes: https://github.com/iron-fish/website/issues/198

## Testing Plan
Before:
![185252851-d27004d4-dc6f-40f7-841c-13273a43a804 (1)](https://user-images.githubusercontent.com/92462002/186995296-ef446ce2-5005-4fb5-be34-2a42bf14ecad.png)

After:
![IMG_0771](https://user-images.githubusercontent.com/92462002/186995356-3a371c85-bc3e-4376-a4a9-58b0182f4794.jpg)




## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.
No
```
[ ] Yes
```
