### PR TITLE
Changed background linear gradient for blog posts

### DIFF
--- a/src/theme/BlogListPage/styles.module.css
+++ b/src/theme/BlogListPage/styles.module.css
@@ -84,7 +84,7 @@
   height: 100%;
   width: 100%;
   position: relative;
-  background: linear-gradient(359.82deg, #000000 0.14%, rgba(0, 0, 0, 0) 52.2%);
+  background: linear-gradient(359.82deg, #000000 0.14%, rgba(0, 0, 0, 0) 78.2%);
   font-family: var(--ifm-font-header-button);
   font-size: 32px;
   line-height: 38px;


### PR DESCRIPTION
## Summary
Changing the linear gradient percentage as 78.2% caused the white text to not blend in with white background. The percentage was not increased further to facilitate the aesthetics of the photos at the same time.

Solves: https://github.com/iron-fish/website/issues/198

## Testing Plan
See before after below.

Before:
<img width="288" alt="Screen Shot 2022-09-30 at 8 18 36 PM" src="https://user-images.githubusercontent.com/114656810/193302665-15f0947a-ea5c-4505-a3b8-969301d60768.png">
<img width="279" alt="Screen Shot 2022-09-30 at 8 18 42 PM" src="https://user-images.githubusercontent.com/114656810/193302619-cfb1f95d-1b00-4afe-bb66-a83d93fc3c03.png">


After:
<img width="281" alt="Screen Shot 2022-09-30 at 8 10 48 PM" src="https://user-images.githubusercontent.com/114656810/193302364-760ac8ec-1e82-4dc7-b8ed-db8365f2e5ef.png">
<img width="282" alt="Screen Shot 2022-09-30 at 8 10 54 PM" src="https://user-images.githubusercontent.com/114656810/193302382-5d2b0f09-f22d-40aa-89a2-382da73df36d.png">


## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.
No
```
[ ] Yes
```
