### PR TITLE
Add blake3 to mining whitepaper

### DIFF
--- a/docs/whitepaper/4_mining.md
+++ b/docs/whitepaper/4_mining.md
@@ -129,4 +129,4 @@ A Block Header consists of the following data:
 
 ### Iron Fish Hashing Algorithm
 
-The specifics of the Hashing Algorithm will be announced closer to launch date.
+Iron Fish currently uses Blake3 hashing algorithm, but is subject to change any time, including at mainnet launch.


### PR DESCRIPTION
## Summary

The whitepaper still says the hash is TBD but we decide on blake3 over a year ago and never updated this.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
