### PR TITLE
Update ironfish config cmd on the website

### DIFF
--- a/docs/onboarding/cli.md
+++ b/docs/onboarding/cli.md
@@ -60,10 +60,10 @@ ironfish reset
 ```
 
 ### Config
-#### config:show
+#### config
 Prints out the content of your config file
 ```sh
-ironfish config:show
+ironfish config
 ```
 #### config:edit
 Opens the config file with your default code editor


### PR DESCRIPTION
## Summary
We rename the  `ironfish config:show` to` ironfish config`, update the website doc since user are reporting ironfish config:show does not work.
https://github.com/iron-fish/website/pull/294

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
