### PR TITLE
Cleanup post-merge RPC HTTP example items

### DIFF
--- a/docs/onboarding/rpc/chain.md
+++ b/docs/onboarding/rpc/chain.md
@@ -191,7 +191,7 @@ import Terminal from '../../../src/theme/components/Terminal/Terminal'
 import GetBlock from '../../../src/theme/components/Terminal/rpc/GetBlock'
 
 ```
-curl -d "{\"sequence\": 1}" -X POST http://localhost:8080/chain/getBlock
+curl -d '{"sequence": 1}' -X POST http://localhost:8021/chain/getBlock
 ```
 <Terminal command={GetBlock} />
 

--- a/docs/onboarding/rpc/node.md
+++ b/docs/onboarding/rpc/node.md
@@ -135,7 +135,7 @@ import Terminal from '../../../src/theme/components/Terminal/Terminal'
 import GetStatus from '../../../src/theme/components/Terminal/rpc/GetStatus'
 
 ```
-curl -X POST http://localhost:8080/node/getStatus
+curl -X POST http://localhost:8021/node/getStatus
 ```
 
 <Terminal command={GetStatus} />

--- a/src/theme/components/Terminal/rpc/GetBlock.js
+++ b/src/theme/components/Terminal/rpc/GetBlock.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 
 export default [
-    <span data-ty="input">{`curl -d "{\\\"sequence\\\": 1}" -X POST http://localhost:8080/chain/getBlock`}</span>,
+    <span data-ty="input">{`curl -d '{"sequence": 1}' -X POST http://localhost:8080/chain/getBlock`}</span>,
     <span data-ty>
     {
 `{

--- a/src/theme/components/Terminal/rpc/GetBlock.js
+++ b/src/theme/components/Terminal/rpc/GetBlock.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 
 export default [
-    <span data-ty="input">{`curl -d '{"sequence": 1}' -X POST http://localhost:8080/chain/getBlock`}</span>,
+    <span data-ty="input">{`curl -d '{"sequence": 1}' -X POST http://localhost:8021/chain/getBlock`}</span>,
     <span data-ty>
     {
 `{

--- a/src/theme/components/Terminal/rpc/GetStatus.js
+++ b/src/theme/components/Terminal/rpc/GetStatus.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 
 export default [
-    <span data-ty="input">curl -X POST http://localhost:8080/node/getStatus</span>,
+    <span data-ty="input">curl -X POST http://localhost:8021/node/getStatus</span>,
     <span data-ty>
     {`
 {


### PR DESCRIPTION
## Summary
- use single quotes to avoid need for escaping
- hit our default port `8021` in the examples, not `8080`

## Testing Plan
Re-ran commands to confirm they worked, local-hosted the website to make sure it looked right.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
