### PR TITLE
fixes the description of wallet/getAccountsStatus

### DIFF
--- a/docs/onboarding/rpc/wallet.md
+++ b/docs/onboarding/rpc/wallet.md
@@ -304,7 +304,7 @@ Returns an account's public key.
 
 ## wallet/getAccountsStatus
 
-Returns an account's public key.
+Returns the status of an account or of all accounts if no account is provided.
 
 #### Request
 


### PR DESCRIPTION
## Summary

RPC docs description duplicated from wallet/getPublicKey

changes description to match RPC endpoint response

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
