### PR TITLE
updates docs for wallet commands

### DIFF
--- a/docs/onboarding/wallet.md
+++ b/docs/onboarding/wallet.md
@@ -16,13 +16,14 @@ import CheckDefault from '../../src/theme/components/Terminal/Wallet/CheckDefaul
 import Export from '../../src/theme/components/Terminal/Wallet/Export'
 import PubKey from '../../src/theme/components/Terminal/Wallet/PubKey'
 import Import from '../../src/theme/components/Terminal/Wallet/Import'
-import Remove from '../../src/theme/components/Terminal/Wallet/Remove'
+import Delete from '../../src/theme/components/Terminal/Wallet/Delete'
 import Send from '../../src/theme/components/Terminal/Wallet/Send'
 import Rescan from '../../src/theme/components/Terminal/Wallet/Rescan'
 import Transactions from '../../src/theme/components/Terminal/Wallet/Transactions'
 import Notes from '../../src/theme/components/Terminal/Wallet/Notes'
 import Mint from '../../src/theme/components/Terminal/Wallet/Mint'
 import Burn from '../../src/theme/components/Terminal/Wallet/Burn'
+import Assets from '../../src/theme/components/Terminal/Wallet/Assets'
 
 
 
@@ -97,28 +98,35 @@ ironfish wallet:accounts
 <Terminal command={List} />
 
 ### Account address
-To see a specific account public key
+To see the public key for an account
 ```sh
 ironfish wallet:address
 ```
 <Terminal command={PubKey} />
 
+### Account assets
+To see the custom assets for an account
+```sh
+ironfish wallet:assets
+```
+<Terminal command={Assets} />
+
 ### Account balance
-To display the balance of the account
+To display the balance of an account
 ```sh
 ironfish wallet:balance
 ```
 <Terminal command={CheckBalance} />
 
 ### Account balances
-To display the balance of all assests on the account
+To display the balance of all assets on an account
 ```sh
 ironfish wallet:balances
 ```
 <Terminal command={CheckBalances} />
 
 ### Account notes
-To display the notes of the account
+To display the notes of an account
 ```sh
 ironfish wallet:notes
 ```
@@ -127,9 +135,9 @@ ironfish wallet:notes
 ### Account deletion
 To delete an account
 ```sh
-ironfish wallet:remove MyAccount
+ironfish wallet:delete MyAccount
 ```
-<Terminal command={Remove} />
+<Terminal command={Delete} />
 
 ### Mint a new asset
 To mint a new asset
@@ -166,4 +174,4 @@ ironfish wallet:rescan
 ```
 <Terminal command={Rescan} />
 
-Wait for scanning to get completed
+Wait for scanning to complete

--- a/src/theme/components/Terminal/Wallet/AllCommands.js
+++ b/src/theme/components/Terminal/Wallet/AllCommands.js
@@ -9,19 +9,25 @@ List all the accounts on the node
 USAGE
   $ ironfish wallet:COMMAND
 
+TOPICS
+  wallet:transaction  Display an account transaction
+
 COMMANDS
   wallet:accounts      List all the accounts on the node
   wallet:address       Display your account address
+  wallet:assets        Display the wallet's assets
   wallet:balance       Display the account balance
   wallet:balances      Display the account's balances for all assets
   wallet:burn          Burn tokens and decrease supply for a given asset
   wallet:create        Create a new account for sending and receiving coins
+  wallet:delete        Permanently delete an account
   wallet:export        Export an account
   wallet:import        Import an account
   wallet:mint          Mint tokens and increase supply for a given asset
   wallet:notes         Display the account notes
-  wallet:remove        Permanently remove an account
-  wallet:repair        Repairs wallet database stores
+  wallet:post          Post a raw transaction
+  wallet:prune         Removes expired transactions from the wallet
+  wallet:repair        Repair wallet database stores
   wallet:rescan        Rescan the blockchain for transaction
   wallet:send          Send coins to another account
   wallet:status        Get status of an account

--- a/src/theme/components/Terminal/Wallet/Assets.js
+++ b/src/theme/components/Terminal/Wallet/Assets.js
@@ -1,0 +1,12 @@
+import React, { useEffect, useState } from "react";
+
+export default [
+    <span data-ty="input">ironfish wallet:assets</span>,
+    <span data-ty>
+    {`
+ Name     ID            Metadata               Status      Supply  Owner         
+ ──────── ───────────── ────────────────────── ─────────── ─────── ───────────── 
+ custom   89457...befb5 a custom asset         confirmed   42      89f22...a20ce
+    `}
+  </span>,
+];

--- a/src/theme/components/Terminal/Wallet/CheckBalance.js
+++ b/src/theme/components/Terminal/Wallet/CheckBalance.js
@@ -5,7 +5,7 @@ export default [
     <span data-ty>
     {`
 Account: default
-Balance: $IRON 0.00000000
+Available Balance: $IRON 0.00000000
         `}
   </span>,
 ];

--- a/src/theme/components/Terminal/Wallet/CheckBalances.js
+++ b/src/theme/components/Terminal/Wallet/CheckBalances.js
@@ -5,7 +5,7 @@ export default [
     <span data-ty>
     {`
 Account: default
-Asset Name Asset Id                                                         Confirmed Balance
+Asset Name Asset Id                                                         Available Balance
 ────────── ──────────────────────────────────────────────────────────────── ─────────────────
 $IRON      d7c86706f5817aa718cd1cfad03233bcd64a7789fd9422d3b17af6823a7e6ac6 24900000.00045900
         `}

--- a/src/theme/components/Terminal/Wallet/Delete.js
+++ b/src/theme/components/Terminal/Wallet/Delete.js
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react";
 
 export default [
-    <span data-ty="input">ironfish wallet:remove wallet</span>,
+    <span data-ty="input">ironfish wallet:delete wallet</span>,
     <span data-ty>
     {`
-Account 'wallet' successfully removed.
+Account 'wallet' successfully deleted.
         `}
   </span>,
 ];

--- a/src/theme/components/Terminal/Wallet/Notes.js
+++ b/src/theme/components/Terminal/Wallet/Notes.js
@@ -4,14 +4,10 @@ export default [
     <span data-ty="input">ironfish wallet:notes</span>,
     <span data-ty>
     {`
- default (8454944) - Account notes
-
- Spender Amount ($IRON) Memo  From Transaction                                                 
- ─────── ────────────── ───── ──────────────────────────────────────────────────────────────── 
- ✔       0.1            wd021 00104ad284dd573cf3c2b3e72f5dfa0bd9a10f825aaf180853820e30e98062b5
- x       15.69999963          00104ad284dd573cf3c2b3e72f5dfa0bd9a10f825aaf180853820e30e98062b5
- ✔       0.1            wd021 00d3558f24c83cfa82928060692c7839194d91f5a81d9c031e0238850f4afd1b
- x       8.3999989            00d3558f24c83cfa82928060692c7839194d91f5a81d9c031e0238850f4afd1b
+ Memo  Sender   From Transaction Spent Asset         Amount    
+ ───── ──────── ──────────────── ───── ───────────── ──────────
+       89f22... b780011..d0d90d0       $IRON (d7c86) 0.00000001
+       89f22... a436011..d0d90d0 ✔     $IRON (d7c86) 0.00000004
         `}
   </span>,
 ];

--- a/src/theme/components/Terminal/Wallet/Send.js
+++ b/src/theme/components/Terminal/Wallet/Send.js
@@ -5,7 +5,7 @@ export default [
       <span
         data-ty="input"
         data-ty-type-delay="400"
-        data-ty-prompt="Enter the amount in $IRON (balance available: $IRON 200)"
+        data-ty-prompt="Enter the amount in $IRON (balance: $IRON 200)"
       >
         20
       </span>,
@@ -27,8 +27,6 @@ export default [
         {`
 You are about to send:
 $IRON 20 to ab518b8c908d7157eaebdf8159c5813894074d3136826daba4a485598de1b86a597af2821f8400bbfe70c1 from the account IronFishGenesisAccount
-
-* This action is NOT reversible *
 `}
       </span>,
       <span

--- a/src/theme/components/Terminal/Wallet/Transactions.js
+++ b/src/theme/components/Terminal/Wallet/Transactions.js
@@ -4,13 +4,10 @@ export default [
     <span data-ty="input">ironfish wallet:transactions</span>,
     <span data-ty>
     {`
- default (8454944) - Account transactions
-
- Status    Creator Hash                        Miner Fee Fee ($ORE)  Notes Spends 
- ───────── ─────── ─────────────────────────── ───────── ─────────── ───── ──────   
- pending   ✔       02ad86094df3bd5a1e090b..... x         1           2     1      
- completed ✔       04090cc860d4a71b4be50a..... x         1           2     1      
- completed x       04718dcc81bea11fdb4b38..... ✔         -2000000006 1     0    
+Timestamp               Status    Type    Hash     Expiration Fee Paid ($IRON) Asset         Net Amount 
+─────────────────────── ───────── ─────── ──────── ────────── ──────────────── ───────────── ───────────
+3/9/2023 6:08:57 PM PST confirmed send    aa72c... 75076      0.00000001       $IRON (d7c86) -0.00000003
+3/9/2023 2:26:48 PM PST confirmed receive a4360... 74854                       $IRON (d7c86) 0.00000001 
         `}
   </span>,
 ];


### PR DESCRIPTION
## Summary

- updates text from 'wallet --help'
- adds 'assets' command and Terminal output
- updates Terminal output for balance, balances, transactions, and notes
- renames remove to delete

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
