### PR TITLE
removes 'reset' from rescanAccount request

### DIFF
--- a/docs/onboarding/rpc/wallet.md
+++ b/docs/onboarding/rpc/wallet.md
@@ -506,7 +506,6 @@ Rescans an account in the wallet, updating the balance and available notes.
 <JsDisplay js={`{
   follow?: boolean
   from?: number
-  reset?: boolean
 }
 `} />
 


### PR DESCRIPTION
## Summary

following https://github.com/iron-fish/ironfish/pull/3654 'reset' is no longer a request parameter for rescanAccount and all rescans will reset the wallet database.

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
