### PR TITLE
uses enum values in wallet transaction rpc docs

### DIFF
--- a/docs/onboarding/rpc/wallet.md
+++ b/docs/onboarding/rpc/wallet.md
@@ -351,8 +351,8 @@ Returns a transaction for an account.
   account: string
   transaction: {
     hash: string
-    status: string
-    type: string
+    status: 'confirmed' | 'expired' | 'pending' | 'unconfirmed' | 'unknown'
+    type: 'send' | 'receive' | 'miner'
     fee: string
     blockHash?: string
     blockSequence?: number
@@ -385,8 +385,8 @@ Returns transactions for an account. The default account is used if no account i
 #### Response
 
 <JsDisplay js={`{
-  status: string
-  type: string
+  status: 'confirmed' | 'expired' | 'pending' | 'unconfirmed' | 'unknown'
+  type: 'send' | 'receive' | 'miner'
   hash: string
   fee: string
   notesCount: number


### PR DESCRIPTION
## Summary

transaction status and transaction type can only take one of a set of enum values.

adds the enum values to the rpc docs for getAccountTransaction and getAccountTransactions for transaction status and type response fields

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
