### PR TITLE
docs: add code hyperlinks in rpc onboarding functions + update wordings

### DIFF
--- a/docs/onboarding/rpc/chain.md
+++ b/docs/onboarding/rpc/chain.md
@@ -117,24 +117,28 @@ Follows the chain from a given sequence and streams blocks from chain connects a
     timestamp: number
     work: string
     main: boolean
-    transactions: Array<{
+    transactions:{
       hash: string
       size: number
       fee: number
-      notes: Array<{ commitment: string }>
-      spends: Array<{ nullifier: string }>
-      mints: Array<{
+      notes: { 
+        commitment: string 
+      }[]
+      spends: { 
+        nullifier: string 
+      }[]
+      mints: {
         id: string
         metadata: string
         name: string
         owner: string
         value: string
-      }>
-      burns: Array<{
+      }[]
+      burns: {
         id: string
         value: string
-      }>
-    }>
+      }[]
+    }[]
   }
 }
 `} />
@@ -191,13 +195,13 @@ One of hash or sequence must be provided.
     timestamp: number
     noteSize: number
     noteCommitment: string
-    transactions: Array<{
+    transactions: {
       fee: string
       hash: string
       signature: string
       notes: number
       spends: number
-    }>
+    }[]
   }
   metadata: {
     main: boolean
@@ -385,7 +389,7 @@ Streams transactions from a head sequence given an incoming view key
       assetId: string
       assetName: string
       value: string
-    }[]
+  }[]
     burns: {
       assetId: string
       assetName: string
@@ -417,9 +421,11 @@ If stop and stop values are provided, only the blocks between the start and stop
 `} />
 
 
-## chain/getNoteWitness 
+## <GithubCodeLink link="chain/getNoteWitness" /> chain/getNoteWitness 
 
-Returns a witness (merkle path) to a specified note in the note merkle tree. This witness is necessary for creating a transaction that spends the note. This endpoint would primarily be used to construct transactions without using the Iron Fish wallet. The returned `treeSize` and `rootHash` values will always reference the note merkle tree state at the current HEAD of the chain. If the chain experiences a re-org and the referenced HEAD moves to a fork, this witness will no longer be usable in a transaction.
+Gets a witness (merkle path) to a specified note in the note merkle tree. This witness is necessary for creating a transaction that spends the note. 
+
+This endpoint would primarily be used to construct transactions without using the Iron Fish wallet. The returned `treeSize` and `rootHash` values will always reference the note merkle tree state at the current HEAD of the chain. If the chain experiences a re-org and the referenced HEAD moves to a fork, this witness will no longer be usable in a transaction.
 
 #### Request
 

--- a/docs/onboarding/rpc/chain.md
+++ b/docs/onboarding/rpc/chain.md
@@ -117,28 +117,28 @@ Follows the chain from a given sequence and streams blocks from chain connects a
     timestamp: number
     work: string
     main: boolean
-    transactions:{
+    transactions: Array<{
       hash: string
       size: number
       fee: number
-      notes: { 
+      notes: Array<{ 
         commitment: string 
-      }[]
-      spends: { 
+      }>
+      spends: Array<{ 
         nullifier: string 
-      }[]
-      mints: {
+      }>
+      mints: Array<{
         id: string
         metadata: string
         name: string
         owner: string
         value: string
-      }[]
-      burns: {
+      }>
+      burns: Array<{
         id: string
         value: string
-      }[]
-    }[]
+      }>
+    }>
   }
 }
 `} />
@@ -195,13 +195,13 @@ One of hash or sequence must be provided.
     timestamp: number
     noteSize: number
     noteCommitment: string
-    transactions: {
+    transactions: Array<{
       fee: string
       hash: string
       signature: string
       notes: number
       spends: number
-    }[]
+    }>
   }
   metadata: {
     main: boolean
@@ -340,14 +340,14 @@ Gets a transaction from a block hash and transaction hash
   spendsCount: number
   signature: string
   notesEncrypted: string[]
-  mints: {
+  mints: Array<{
     assetId: string
     value: string
-  }[]
-  burns: {
+  }>
+  burns: Array<{
     assetId: string
     value: string
-  }[]
+  }>
 }
 `} />
 
@@ -376,26 +376,26 @@ Streams transactions from a head sequence given an incoming view key
     sequence: number
     timestamp: number
   }
-  transactions: {
+  transactions: Array<{
     hash: string
     isMinersFee: boolean
-    notes: {
+    notes: Array<{
       assetId: string
       assetName: string
       value: string
       memo: string
-    }[]
-    mints: {
+    }>
+    mints: Array<{
       assetId: string
       assetName: string
       value: string
-  }[]
-    burns: {
+    }>
+    burns: Array< {
       assetId: string
       assetName: string
       value: string
-    }[]
-  }[]
+    }>
+  }>
 }
 `} />
 
@@ -438,9 +438,9 @@ This endpoint would primarily be used to construct transactions without using th
 <JsDisplay js={`{
   treeSize: number
   rootHash: string
-  authPath: {
+  authPath: Array<{
     side: 'Left' | 'Right'
     hashOfSibling: string
-  }[]
+  }>
 }
 `} />

--- a/docs/onboarding/rpc/config.md
+++ b/docs/onboarding/rpc/config.md
@@ -7,10 +7,13 @@ hide_table_of_contents: false
 ---
 
 import JsDisplay from '../../../src/theme/components/Terminal/JsDisplay'
+import GithubCodeLink from '../../../src/theme/components/Terminal/rpc/GithubCodeLink'
 
-## config/getConfig
+## <GithubCodeLink link="config/getConfig"/>config/getConfig
 
-Gets a subset of configuration values for a node
+Gets a subset of configuration values for a node. 
+
+If the user flag is provided, a value will only be returned if the user set the configuration option.
 
 #### Request
 
@@ -90,7 +93,7 @@ Gets a subset of configuration values for a node
 >
 `} />
 
-## config/setConfig
+## <GithubCodeLink link="config/setConfig"/> config/setConfig
 
 Sets a configuration value for the node
 
@@ -107,7 +110,7 @@ Sets a configuration value for the node
 <JsDisplay js={`undefined
 `} />
 
-## config/unsetConfig
+## <GithubCodeLink link="config/unsetConfig"/> config/unsetConfig
 
 Unsets a configuration value for the node and falls back to the default.
 
@@ -123,10 +126,10 @@ Unsets a configuration value for the node and falls back to the default.
 <JsDisplay js={`undefined
 `} />
 
-## config/uploadConfig
+## <GithubCodeLink link="config/uploadConfig"/> config/uploadConfig
 
 Uploads a set of configuration values for the node.
-This resets any previously set config to the default.
+This resets any previously set config options to their default values.
 
 #### Request
 

--- a/docs/onboarding/rpc/event.md
+++ b/docs/onboarding/rpc/event.md
@@ -7,8 +7,9 @@ hide_table_of_contents: false
 ---
 
 import JsDisplay from '../../../src/theme/components/Terminal/JsDisplay'
+import GithubCodeLink from '../../../src/theme/components/Terminal/rpc/GithubCodeLink'
 
-## event/onGossip
+## <GithubCodeLink link="events/onGossip"/> event/onGossip
 
 Streams block headers on gossip events
 

--- a/docs/onboarding/rpc/faucet.md
+++ b/docs/onboarding/rpc/faucet.md
@@ -7,10 +7,15 @@ hide_table_of_contents: false
 ---
 
 import JsDisplay from '../../../src/theme/components/Terminal/JsDisplay'
+import GithubCodeLink from '../../../src/theme/components/Terminal/rpc/GithubCodeLink'
 
-## faucet/getFunds
+## <GithubCodeLink link="faucet/getFunds" /> faucet/getFunds
 
-Submits a request to get funds from the faucet for an account
+**THIS ENDPOINT IS ONLY AVAILABLE ON TESTNET**
+
+Submits a request to get funds from the faucet for an account. 
+
+If an account is not provided, the default account on the node will be used.
 
 #### Request
 

--- a/docs/onboarding/rpc/mempool.md
+++ b/docs/onboarding/rpc/mempool.md
@@ -7,8 +7,9 @@ hide_table_of_contents: false
 ---
 
 import JsDisplay from '../../../src/theme/components/Terminal/JsDisplay'
+import GithubCodeLink from '../../../src/theme/components/Terminal/rpc/GithubCodeLink'
 
-## mempool/getStatus
+## <GithubCodeLink link="mempool/getStatus" /> mempool/getStatus
 
 Gets (and optionally streams) the status of the mempool
 
@@ -34,10 +35,12 @@ Gets (and optionally streams) the status of the mempool
 }
 `} />
 
-## mempool/getTransactions
+## <GithubCodeLink link="mempool/getTransactions" /> mempool/getTransactions
 
-Streams transactions from the mempool
+Streams transactions from the mempool. Transactions are streamed in case there are a large number of transactions in the mempool.
 
+The `MinMax` type specifies the the minimum and maximum range of the input parameter to filter the returned transactions. 
+For example, `feeRate={min: 30; max:60}` specifies that only transactions with `30 <= txn.feeRate <= 60` are returned.
 #### Request
 
 <JsDisplay js={`{

--- a/docs/onboarding/rpc/miner.md
+++ b/docs/onboarding/rpc/miner.md
@@ -7,8 +7,9 @@ hide_table_of_contents: false
 ---
 
 import JsDisplay from '../../../src/theme/components/Terminal/JsDisplay'
+import GithubCodeLink from '../../../src/theme/components/Terminal/rpc/GithubCodeLink'
 
-## miner/blockTemplateStream
+## <GithubCodeLink link="mining/blockTemplateStream" /> miner/blockTemplateStream
 
 Streams block templates from the chain for mining blocks
 
@@ -38,9 +39,9 @@ Streams block templates from the chain for mining blocks
 }
 `} />
 
-## miner/submitBlock
+## <GithubCodeLink link="mining/submitBlock" /> miner/submitBlock
 
-Submit block templates to the mining manager
+Submit a block template to the mining manager.
 
 #### Request
 

--- a/docs/onboarding/rpc/node.md
+++ b/docs/onboarding/rpc/node.md
@@ -7,10 +7,11 @@ hide_table_of_contents: false
 ---
 
 import JsDisplay from '../../../src/theme/components/Terminal/JsDisplay'
+import GithubCodeLink from '../../../src/theme/components/Terminal/rpc/GithubCodeLink'
 
-## node/getLogStream
+## <GithubCodeLink link="node/getLogStream" /> node/getLogStream
 
-Gets a log stream from the node
+Streams logs from the node
 
 #### Request
 
@@ -28,7 +29,7 @@ Gets a log stream from the node
 }
 `} />
 
-## node/getStatus
+## <GithubCodeLink link="node/getStatus" /> node/getStatus
 
 Gets (and optionally streams) the node's status
 
@@ -131,7 +132,7 @@ Gets (and optionally streams) the node's status
 }
 `} />
 
-## node/stopNode
+## <GithubCodeLink link="node/stopNode" /> node/stopNode
 
 Shuts the node down
 

--- a/docs/onboarding/rpc/peer.md
+++ b/docs/onboarding/rpc/peer.md
@@ -7,8 +7,9 @@ hide_table_of_contents: false
 ---
 
 import JsDisplay from '../../../src/theme/components/Terminal/JsDisplay'
+import GithubCodeLink from '../../../src/theme/components/Terminal/rpc/GithubCodeLink'
 
-## peer/getBannedPeers
+## <GithubCodeLink link="peers/getBannedPeers" /> peer/getBannedPeers
 
 Gets (and optionally streams) banned peers from the node's peer network
 
@@ -22,14 +23,14 @@ Gets (and optionally streams) banned peers from the node's peer network
 #### Response
 
 <JsDisplay js={`{
-  peers: Array<{
+  peers: {
     identity: string
     reason: string
-  }>
+  }[]
 }
 `} />
 
-## peer/getPeer
+## <GithubCodeLink link="peers/getPeer" /> peer/getPeer
 
 Gets (and optionally streams) peer data from an identity
 
@@ -82,7 +83,7 @@ Gets (and optionally streams) peer data from an identity
 }
 `} />
 
-## peer/getPeerMessages
+## <GithubCodeLink link="peers/getPeerMessages" /> peer/getPeerMessages
 
 Gets (and optionally streams) peer messages from an identity
 
@@ -108,7 +109,7 @@ Gets (and optionally streams) peer messages from an identity
 }
 `} />
 
-## peer/getPeers
+## <GithubCodeLink link="peers/getPeers" /> peer/getPeers
 
 Gets (and optionally streams) peers from the node's peer network
 
@@ -122,7 +123,7 @@ Gets (and optionally streams) peers from the node's peer network
 #### Response
 
 <JsDisplay js={`{
-  peers: Array<{
+  peers: {
     state: string
     identity: string | null
     version: number | null
@@ -156,7 +157,7 @@ Gets (and optionally streams) peers from the node's peer network
     features: {
       syncing: boolean
     } | null
-  }>
+  }[]
 }
 `} />
 

--- a/docs/onboarding/rpc/peer.md
+++ b/docs/onboarding/rpc/peer.md
@@ -23,10 +23,10 @@ Gets (and optionally streams) banned peers from the node's peer network
 #### Response
 
 <JsDisplay js={`{
-  peers: {
+  peers: Array<{
     identity: string
     reason: string
-  }[]
+  }>
 }
 `} />
 
@@ -123,7 +123,7 @@ Gets (and optionally streams) peers from the node's peer network
 #### Response
 
 <JsDisplay js={`{
-  peers: {
+  peers: Array<{
     state: string
     identity: string | null
     version: number | null
@@ -157,7 +157,7 @@ Gets (and optionally streams) peers from the node's peer network
     features: {
       syncing: boolean
     } | null
-  }[]
+  }>
 }
 `} />
 

--- a/docs/onboarding/rpc/rpc.md
+++ b/docs/onboarding/rpc/rpc.md
@@ -24,7 +24,7 @@ Gets (and optionally streams) the status of the RPC server
 
 <JsDisplay js={`{
   started: boolean
-  adapters: {
+  adapters: Array<{
     name: string
     inbound: number
     outbound: number
@@ -34,6 +34,6 @@ Gets (and optionally streams) the status of the RPC server
     writtenBytes: number
     clients: number
     pending: string[]
-  }[]
+  }>
 }
 `} />

--- a/docs/onboarding/rpc/rpc.md
+++ b/docs/onboarding/rpc/rpc.md
@@ -7,10 +7,11 @@ hide_table_of_contents: false
 ---
 
 import JsDisplay from '../../../src/theme/components/Terminal/JsDisplay'
+import GithubCodeLink from '../../../src/theme/components/Terminal/rpc/GithubCodeLink'
 
-## rpc/getStatus
+## <GithubCodeLink link="rpc/getStatus"/> rpc/getStatus
 
-Gets status of the RPC server
+Gets (and optionally streams) the status of the RPC server
 
 #### Request
 

--- a/docs/onboarding/rpc/wallet.md
+++ b/docs/onboarding/rpc/wallet.md
@@ -59,7 +59,7 @@ Creates a transaction burning a custom asset from a given account, posts the tra
 
 ##  <GithubCodeLink link="wallet/create"/> wallet/create
 
-Creates a new account in the wallet with the given name and optionally setting it as the default account.
+Creates a new account in the wallet with the given name and optionally sets it as the default account.
 
 #### Request
 
@@ -88,22 +88,22 @@ The serialized new transaction is returned.
 
 <JsDisplay js={`{
   account: string
-  outputs: {
+  outputs: Array<{
     publicAddress: string
     amount: string
     memo: string
     assetId?: string
-  }[]
-  mints?: {
+  }>
+  mints?: Array<{
     assetId?: string
     name?: string
     metadata?: string
     value: string
-  }[]
-  burns?: {
+  }>
+  burns?: Array<{
     assetId: string
     value: string
-  }[]
+  }>
   fee?: string | null
   feeRate?: string | null
   expiration?: number
@@ -123,7 +123,7 @@ The serialized new transaction is returned.
 
 Exports the keys to the default account, or the named account if specified. 
 
-If `viewOnly = true`, the returned spending key will be null, but the spending key may also be null if exporting a view-only account.
+`spendingKey` will be null in the response if `viewOnly = true` or if exporting a view-only account.
 
 #### Request
 
@@ -239,7 +239,7 @@ Gets the wallet's `$IRON` balance, as well as balances of custom assets of the g
 
 <JsDisplay js={`{
   account: string
-  balances: {
+  balances: Array<{
     assetId: string
     assetName: string
     assetOwner: string
@@ -251,7 +251,7 @@ Gets the wallet's `$IRON` balance, as well as balances of custom assets of the g
     available: string
     blockHash: string | null
     sequence: number | null
-  }[]
+  }>
 }
 `} />
 
@@ -404,11 +404,11 @@ Gets transactions for the given account. If not specified, the default account i
   burnsCount: number
   expiration: number
   timestamp: number
-  assetBalanceDeltas: { 
+  assetBalanceDeltas: Array<{ 
     assetId: string 
     assetName: string
     delta: string 
-  }[]
+  }>
 }
 `} />
 
@@ -540,12 +540,12 @@ Creates a transaction, posts the transaction, and submits it to the wallet, memp
 
 <JsDisplay js={`{
   account: string
-  outputs: {
+  outputs: Array<{
     publicAddress: string
     amount: string
     memo: string
     assetId?: string
-  }[]
+  }>
   fee: string
   expiration?: number | null
   expirationDelta?: number | null

--- a/docs/onboarding/rpc/wallet.md
+++ b/docs/onboarding/rpc/wallet.md
@@ -7,10 +7,13 @@ hide_table_of_contents: false
 ---
 
 import JsDisplay from '../../../src/theme/components/Terminal/JsDisplay'
+import GithubCodeLink from '../../../src/theme/components/Terminal/rpc/GithubCodeLink'
 
-## wallet/addTransaction
+## <GithubCodeLink link="wallet/addTransaction"/> wallet/addTransaction
 
-Takes in a posted transaction, adds it to the wallet and mempool, and optionally broadcasts it to the network. Returns the names of the wallet accounts involved in the transaction.
+Takes in a posted transaction, adds it to the wallet and mempool, and optionally broadcasts it to the network. 
+
+Returns the names of the wallet accounts involved in the transaction.
 
 #### Request
 
@@ -27,7 +30,7 @@ Takes in a posted transaction, adds it to the wallet and mempool, and optionally
 }
 `} />
 
-## wallet/burnAsset
+## <GithubCodeLink link="wallet/burnAsset"/> wallet/burnAsset
 
 Creates a transaction burning a custom asset from a given account, posts the transaction, and submits it to the wallet, mempool, and network.
 
@@ -54,9 +57,9 @@ Creates a transaction burning a custom asset from a given account, posts the tra
 }
 `} />
 
-## wallet/create
+##  <GithubCodeLink link="wallet/create"/> wallet/create
 
-Creates a new account in the wallet with the given name, optionally setting it as the default account.
+Creates a new account in the wallet with the given name and optionally setting it as the default account.
 
 #### Request
 
@@ -75,9 +78,11 @@ Creates a new account in the wallet with the given name, optionally setting it a
 }
 `} />
 
-## wallet/createTransaction
+##  <GithubCodeLink link="wallet/createTransaction"/> wallet/createTransaction
 
-Creates and returns a new transaction with the given parameters, but doesn't post it (as such, it's also not added to the wallet, mempool, or broadcast to the network). This allows for the transaction to be posted using spending keys stored on a different node.
+Creates a new transaction with the given parameters, but does not post it (as such, it is also not added to the wallet, mempool, or broadcast to the network). This allows for the transaction to be posted using spending keys stored on a different node.
+
+The serialized new transaction is returned.
 
 #### Request
 
@@ -114,9 +119,11 @@ Creates and returns a new transaction with the given parameters, but doesn't pos
 }
 `} />
 
-## wallet/exportAccount
+## <GithubCodeLink link="wallet/exportAccount"/> wallet/exportAccount
 
-Exports the keys to the default account, or the named account if specified. If `viewOnly` is true, the spending key will be null, but the spending key may also be null if exporting a view-only account.
+Exports the keys to the default account, or the named account if specified. 
+
+If `viewOnly = true`, the returned spending key will be null, but the spending key may also be null if exporting a view-only account.
 
 #### Request
 
@@ -141,9 +148,9 @@ Exports the keys to the default account, or the named account if specified. If `
 }
 `} />
 
-## wallet/getAccounts
+## <GithubCodeLink link="wallet/getAccounts"/> wallet/getAccounts
 
-Returns accounts in the wallet.
+Gets the names of the accounts in the wallet.
 
 #### Request
 
@@ -160,9 +167,9 @@ Returns accounts in the wallet.
 }
 `} />
 
-## wallet/getAssets
+## <GithubCodeLink link="wallet/getAssets"/> wallet/getAssets
 
-Returns assets in the wallet.
+Streams all the assets in the wallet of the given account. If not specified, the assets of default account will be returned.
 
 #### Request
 
@@ -185,9 +192,10 @@ Returns assets in the wallet.
 }
 `} />
 
-## wallet/getBalance
+## <GithubCodeLink link="wallet/getBalance"/> wallet/getBalance
 
-Returns the wallet balance for a given asset, or $IRON if none is specified.
+Gets the wallet balance for the given account and asset. If the account is not specified,
+the default account will be used. If the asset is not specified, `$IRON` will be used.
 
 #### Request
 
@@ -215,9 +223,9 @@ Returns the wallet balance for a given asset, or $IRON if none is specified.
 }
 `} />
 
-## wallet/getBalances
+## <GithubCodeLink link="wallet/getBalances"/> wallet/getBalances
 
-Returns the wallet's $IRON balance, as well as balances of custom assets.
+Gets the wallet's `$IRON` balance, as well as balances of custom assets of the given account. If the account is not specified, the default account will be used.
 
 #### Request
 
@@ -247,9 +255,9 @@ Returns the wallet's $IRON balance, as well as balances of custom assets.
 }
 `} />
 
-## wallet/getDefaultAccount
+## <GithubCodeLink link="wallet/getDefaultAccount"/> wallet/getDefaultAccount
 
-Returns the wallet's default account.
+Gets the default account of the wallet.
 
 #### Request
 
@@ -265,9 +273,9 @@ Returns the wallet's default account.
 }
 `} />
 
-## wallet/getAccountNotesStream
+## <GithubCodeLink link="wallet/getNotes"/> wallet/getAccountNotesStream
 
-Returns a stream of notes in an account.
+Streams the notes in the given account. If the account is not specified, the default account will be used.
 
 #### Request
 
@@ -289,9 +297,9 @@ Returns a stream of notes in an account.
 }
 `} />
 
-## wallet/getPublicKey
+## <GithubCodeLink link="wallet/getPublicKey"/> wallet/getPublicKey
 
-Returns an account's public key.
+Gets the public key of the given account. If the account is not specified, the default account will be used.
 
 #### Request
 
@@ -308,9 +316,9 @@ Returns an account's public key.
 }
 `} />
 
-## wallet/getAccountsStatus
+## <GithubCodeLink link="wallet/getStatus"/> wallet/getAccountStatus
 
-Returns the status of an account or of all accounts if no account is provided.
+Gets the status of an account. If not specified, the status of all accounts are returned.
 
 #### Request
 
@@ -322,19 +330,19 @@ Returns the status of an account or of all accounts if no account is provided.
 #### Response
 
 <JsDisplay js={`{
-  accounts: Array<{
+  accounts: {
     name: string
     id: string
     headHash: string
     headInChain: boolean
     sequence: string | number
-  }>
+  }[]
 }
 `} />
 
-## wallet/getAccountTransaction
+## <GithubCodeLink link="wallet/getTransaction"/> wallet/getAccountTransaction
 
-Returns a transaction for an account.
+Gets a transaction for an account. If the account is not specified, the default account is used.
 
 #### Request
 
@@ -367,9 +375,9 @@ Returns a transaction for an account.
 }
 `} />
 
-## wallet/getAccountTransactions
+## <GithubCodeLink link="wallet/getTransactions"/> wallet/getAccountTransactions
 
-Returns transactions for an account. The default account is used if no account is provided.
+Gets transactions for the given account. If not specified, the default account is used.
 
 #### Request
 
@@ -396,13 +404,17 @@ Returns transactions for an account. The default account is used if no account i
   burnsCount: number
   expiration: number
   timestamp: number
-  assetBalanceDeltas: Array<{ assetId: string; assetName: string; delta: string }>
+  assetBalanceDeltas: { 
+    assetId: string 
+    assetName: string
+    delta: string 
+  }[]
 }
 `} />
 
-## wallet/importAccount
+## <GithubCodeLink link="wallet/importAccount"/> wallet/importAccount
 
-Imports an account to the wallet.
+Imports an account into the wallet.
 
 #### Request
 
@@ -429,7 +441,7 @@ Imports an account to the wallet.
 }
 `} />
 
-## wallet/mintAsset
+## <GithubCodeLink link="wallet/mintAsset"/> wallet/mintAsset
 
 Creates a transaction minting a custom asset from a given account, posts the transaction, and submits it to the wallet, mempool, and network.
 
@@ -458,10 +470,11 @@ Creates a transaction minting a custom asset from a given account, posts the tra
 }
 `} />
 
-## wallet/postTransaction
+## <GithubCodeLink link="wallet/postTransaction"/> wallet/postTransaction
 
-Posts a transaction, submitting it to the wallet, mempool, and network if possible.
+Posts a transaction and submits it to the wallet, mempool, and network if possible.
 
+Returns the serialized transaction.
 #### Request
 
 <JsDisplay js={`{
@@ -478,7 +491,7 @@ Posts a transaction, submitting it to the wallet, mempool, and network if possib
 }
 `} />
 
-## wallet/removeAccount
+## <GithubCodeLink link="wallet/removeAccount"/> wallet/removeAccount
 
 Removes an account from the wallet.
 
@@ -498,9 +511,9 @@ Removes an account from the wallet.
 }
 `} />
 
-## wallet/rescanAccount
+## <GithubCodeLink link="wallet/rescanAccount"/> wallet/rescanAccount
 
-Rescans an account in the wallet, updating the balance and available notes.
+Rescans an account in the wallet and updates the balance and available notes.
 
 #### Request
 
@@ -519,7 +532,7 @@ Rescans an account in the wallet, updating the balance and available notes.
 }
 `} />
 
-## wallet/sendTransaction
+## <GithubCodeLink link="wallet/sendTransaction"/> wallet/sendTransaction
 
 Creates a transaction, posts the transaction, and submits it to the wallet, mempool, and network.
 
@@ -549,9 +562,9 @@ Creates a transaction, posts the transaction, and submits it to the wallet, memp
 }
 `} />
 
-## wallet/useAccount
+## <GithubCodeLink link="wallet/useAccount"/> wallet/useAccount
 
-Sets an account as the wallet's default account.
+Sets an account as the default account of the wallet.
 
 #### Request
 

--- a/docs/onboarding/rpc/worker.md
+++ b/docs/onboarding/rpc/worker.md
@@ -30,12 +30,12 @@ Gets (and optionally streams) the status of the long-running jobs queued by the 
   executing: number
   change: number
   speed: number
-  jobs: {
+  jobs: Array<{
     name: string
     complete: number
     execute: number
     queue: number
     error: number
-  }[]
+  }>
 }
 `} />

--- a/docs/onboarding/rpc/worker.md
+++ b/docs/onboarding/rpc/worker.md
@@ -7,10 +7,11 @@ hide_table_of_contents: false
 ---
 
 import JsDisplay from '../../../src/theme/components/Terminal/JsDisplay'
+import GithubCodeLink from '../../../src/theme/components/Terminal/rpc/GithubCodeLink'
 
-## worker/getStatus
+## <GithubCodeLink link="workers/getStatus" /> worker/getStatus
 
-Displays info on long-running jobs queued with the node's workers (similar to a threadpool).
+Gets (and optionally streams) the status of the long-running jobs queued by the node's workers. The workers operate similar to a threadpool.
 
 #### Request
 
@@ -29,12 +30,12 @@ Displays info on long-running jobs queued with the node's workers (similar to a 
   executing: number
   change: number
   speed: number
-  jobs: Array<{
+  jobs: {
     name: string
     complete: number
     execute: number
     queue: number
     error: number
-  }>
+  }[]
 }
 `} />


### PR DESCRIPTION
## Summary
Propagates wording improvements and Github code hyperlinks to all pages of the onboarding RPC documentation.

This is an appendum to #337.

Closes IFL-37

## Testing Plan
Sandcastles and waterfalls

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[X] No
```
