### PR TITLE
updates chain/getTransaction docs for optional blockHash

### DIFF
--- a/docs/onboarding/rpc/chain.md
+++ b/docs/onboarding/rpc/chain.md
@@ -326,8 +326,8 @@ Gets a transaction from a block hash and transaction hash
 #### Request
 
 <JsDisplay js={`{ 
-  blockHash: string
   transactionHash: string 
+  blockHash?: string
 }
 `} />
 


### PR DESCRIPTION
## Summary

the blockHash request field will be optional once we'ved added an index from transaction hash to block hash to the chain database

https://github.com/iron-fish/ironfish/pull/3762

## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
