### PR TITLE
Update docs/onboarding/iron-fish-configuration to include HTTP config options

### DIFF
--- a/content/get-started/node-configuration.mdx
+++ b/content/get-started/node-configuration.mdx
@@ -38,6 +38,7 @@ You can change the working directory by passing the flag `--datadir` when runnin
 | enableLogFile                     | Enable logging to a file |
 | enableMetrics                     | Enable internal metrics collection (required for status command) |
 | enableRpc                         | Enable the RPC server |
+| enableRpcHttp                     | Enable the RPC to be served on HTTP |
 | enableRpcIpc                      | Enable the RPC to be served on IPC |
 | enableRpcTcp                      | Enable the RPC to be served on TCP |
 | enableRpcTls                      | Enable the RPC to be served on TLS |
@@ -80,8 +81,10 @@ You can change the working directory by passing the flag `--datadir` when runnin
 | poolRecentShareCutoff             | The length of time in seconds that will be used to calculate hashrate for the pool |
 | poolStatusNotificationInterval    | The length of time in seconds that the pool will wait between status messages |
 | poolSuccessfulPayoutInterval      | The length of time in seconds that the pool will wait between successful payouts |
-| rpcTcpHost                        | Address to connect to when establishing an RPC connection |
-| rpcTcpPort                        | Port to connect to when establishing an RPC connection |
+| rpcTcpHost                        | Address to connect to when establishing an RPC connection over TCP |
+| rpcTcpPort                        | Port to connect to when establishing an RPC connection over TCP |
+| rpcHttpHost                       | Address to connect to when establishing an RPC connection over HTTP |
+| rpcHttpPort                       | Port to connect to when establishing an RPC connection over HTTP |
 | tlsKeyPath                        | Private key path for TLS over TCP |
 | tlsCertPath                       | Node certificate path for authorizing TLS over TCP |
 | targetPeers                       | The ideal number of peers we'd like to be connected to. The node will attempt to establish new connections when below this number. |

--- a/content/get-started/node-configuration.mdx
+++ b/content/get-started/node-configuration.mdx
@@ -81,10 +81,10 @@ You can change the working directory by passing the flag `--datadir` when runnin
 | poolRecentShareCutoff             | The length of time in seconds that will be used to calculate hashrate for the pool |
 | poolStatusNotificationInterval    | The length of time in seconds that the pool will wait between status messages |
 | poolSuccessfulPayoutInterval      | The length of time in seconds that the pool will wait between successful payouts |
-| rpcTcpHost                        | Address to connect to when establishing an RPC connection over TCP |
-| rpcTcpPort                        | Port to connect to when establishing an RPC connection over TCP |
 | rpcHttpHost                       | Address to connect to when establishing an RPC connection over HTTP |
 | rpcHttpPort                       | Port to connect to when establishing an RPC connection over HTTP |
+| rpcTcpHost                        | Address to connect to when establishing an RPC connection over TCP |
+| rpcTcpPort                        | Port to connect to when establishing an RPC connection over TCP |
 | tlsKeyPath                        | Private key path for TLS over TCP |
 | tlsCertPath                       | Node certificate path for authorizing TLS over TCP |
 | targetPeers                       | The ideal number of peers we'd like to be connected to. The node will attempt to establish new connections when below this number. |


### PR DESCRIPTION
## Summary
The config options page didn't include the HTTP configuration options, this PR proposes to add them. 

## Testing Plan
Served locally successfully. Copied and pasted args straight from the page into `config:set` to confirm it was right.

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
```
