### PR TITLE
adds missing 'apt' in Linux install guide

### DIFF
--- a/content/get-started/installation.mdx
+++ b/content/get-started/installation.mdx
@@ -12,7 +12,7 @@ description: Iron Fish Installation | Iron Fish Onboarding
 
 	```sh
 	sudo apt update
-	sudo install build-essential
+	sudo apt install build-essential
 	```
 
 2. Next, install a [command-line git client](https://git-scm.com/download).


### PR DESCRIPTION
fixes typo: incorrect command for installing build-essential package