### PR TITLE
Change titles of RPC

### DIFF
--- a/content/documentation/rpc_chain.mdx
+++ b/content/documentation/rpc_chain.mdx
@@ -1,5 +1,5 @@
 ---
-title: RPC Chain commands
+title: Chain RPCs
 description: RPC Chain | Iron Fish Documentation
 ---
 

--- a/content/documentation/rpc_config.mdx
+++ b/content/documentation/rpc_config.mdx
@@ -1,5 +1,5 @@
 ---
-title: RPC Config commands
+title: Config RPCs
 description: RPC Config | Iron Fish Documentation
 ---
 

--- a/content/documentation/rpc_event.mdx
+++ b/content/documentation/rpc_event.mdx
@@ -1,5 +1,5 @@
 ---
-title: RPC Event commands
+title: Event RPCs
 description: RPC Event | Iron Fish Documentation
 ---
 

--- a/content/documentation/rpc_faucet.mdx
+++ b/content/documentation/rpc_faucet.mdx
@@ -1,5 +1,5 @@
 ---
-title: RPC Faucet commands
+title: Faucet RPCs
 description: RPC Faucet | Iron Fish Documentation
 ---
 

--- a/content/documentation/rpc_mempool.mdx
+++ b/content/documentation/rpc_mempool.mdx
@@ -1,5 +1,5 @@
 ---
-title: RPC Mempool commands
+title: Mempool RPCs
 description: RPC Mempool | Iron Fish Documentation
 ---
 

--- a/content/documentation/rpc_miner.mdx
+++ b/content/documentation/rpc_miner.mdx
@@ -1,5 +1,5 @@
 ---
-title: RPC Miner commands
+title: Miner RPCs
 description: RPC Miner | Iron Fish Documentation
 ---
 

--- a/content/documentation/rpc_node.mdx
+++ b/content/documentation/rpc_node.mdx
@@ -1,5 +1,5 @@
 ---
-title: RPC Node commands
+title: Node RPCs
 description: RPC Node | Iron Fish Documentation
 ---
 

--- a/content/documentation/rpc_peer.mdx
+++ b/content/documentation/rpc_peer.mdx
@@ -1,5 +1,5 @@
 ---
-title: RPC Peer commands
+title: Peer RPCs
 description: RPC Peer | Iron Fish Documentation
 ---
 

--- a/content/documentation/rpc_rpc.mdx
+++ b/content/documentation/rpc_rpc.mdx
@@ -1,5 +1,5 @@
 ---
-title: RPC commands
+title: RPC RPCs
 description: RPC | Iron Fish Documentation
 ---
 

--- a/content/documentation/rpc_wallet.mdx
+++ b/content/documentation/rpc_wallet.mdx
@@ -1,5 +1,5 @@
 ---
-title: RPC Wallet commands
+title: Wallet RPCs
 description: RPC Wallet | Iron Fish Documentation
 ---
 

--- a/content/documentation/rpc_worker.mdx
+++ b/content/documentation/rpc_worker.mdx
@@ -1,5 +1,5 @@
 ---
-title: RPC Worker commands
+title: Worker RPCs
 description: RPC Worker | Iron Fish Documentation
 ---
 


### PR DESCRIPTION
These are not commands, commands are in the CLI. This fixes the names not to refer to commands.