### PR TITLE
adds notice about cpu mining on mainnet

### DIFF
--- a/content/get-started/mining.mdx
+++ b/content/get-started/mining.mdx
@@ -5,6 +5,17 @@ description: Mining | Iron Fish Onboarding
 
 Miners are essential to the health of the Iron Fish network. Without them, blocks won't be generated and transactions won't be transmitted.
 
+⚠️️ **Note:** The instructions on this page are for CPU mining only.
+
+The Iron Fish mainnet will have many miners and mining pools operating more
+powerful GPU miners. CPU mining may be useful for testing, development, and
+learning, but it is not recommended on mainnet.
+
+Please refer to the [mining wiki
+page](https://github.com/iron-fish/ironfish/wiki/Iron-Fish-Launch-Day-Mining)
+for more information on mining and joining a mining pool on the Iron Fish
+mainnet.
+
 ## Requirements
 Install Iron Fish by following the instructions [here](/use/get-started/installation).
 


### PR DESCRIPTION
our website includes directions on how to run a cpu miner, but users who do so will be disappointed if they try to mine on mainnet.

community members have asked that we add a warning not to run a cpu miner on mainnet.