### PR TITLE
adds 'mainnet' command to installation pageo

### DIFF
--- a/content/get-started/installation.mdx
+++ b/content/get-started/installation.mdx
@@ -34,37 +34,44 @@ ironfish
   output={`CLI for running and interacting with an Iron Fish node
 
 VERSION
-  ironfish/0.1.62 darwin-arm64 node-v18.12.1
+  ironfish/1.0.0 linux-x64 node-v18.16.0
 
 USAGE
   $ ironfish [COMMAND]
 
 TOPICS
   blocks      Show the block header of a requested hash or sequence
-  chain       Manage the blockchain
+  ceremony    Contribute randomness to the Iron Fish trusted setup
+  chain       Get the asset info
   config      Print out the entire config
+  mempool     Show the status of the Mempool
   migrations  List all the migration statuses
-  miners      Manage an Iron Fish miner
+  miners      Start a mining pool that connects to a node
   peers       List all connected peers
   rpc         Show the status of the RPC layer
   wallet      List all the accounts on the node
   workers     Show the status of the worker pool
 
 COMMANDS
+  ceremony    Contribute randomness to the Iron Fish trusted setup
   config      Print out the entire config
-  faucet      Receive coins from the Iron Fish official Faucet
+  faucet      Receive coins from the Iron Fish official testnet Faucet
   fees        Get fee distribution for most recent blocks
   help        Display help for ironfish.
   logs        Tail server logs
+  mainnet     Migrate Iron Fish testnet data to mainnet
   migrations  List all the migration statuses
   peers       List all connected peers
   repl        An interactive terminal to the node
   reset       Reset the node to its initial state
   start       Start the node
   status      Show the status of the node
-  stop        Stop the node from running
-  testnet     Set up your node to mine for the testnet`}
+  stop        Stop the node from running`}
 />
+
+### Migrate to Mainnet
+
+To make sure that your node is set up to run on mainnet use `ironfish mainnet`.
 
 ### Update Iron Fish
 

--- a/content/get-started/installation.mdx
+++ b/content/get-started/installation.mdx
@@ -71,7 +71,11 @@ COMMANDS
 
 ### Migrate to Mainnet
 
-To make sure that your node is set up to run on mainnet use `ironfish mainnet`.
+To make sure that your node is set up to run on mainnet use
+
+```sh
+ironfish mainnet
+```
 
 ### Update Iron Fish
 


### PR DESCRIPTION
users need to run `ironfish mainnet`, but we don't mention it.

- updates CLI output to v1.0.0
- adds 'Migrate to Mainnet' section