### PR TITLE
updates integration examples of sdk init to use dataDir

### DIFF
--- a/content/documentation/integration_rpc.mdx
+++ b/content/documentation/integration_rpc.mdx
@@ -18,8 +18,7 @@ fetch your account’s public address looks like:
 
 ```js
 async function main(): Promise<void> {
-  const config = JSON.parse((await fsAsync.readFile('.ironfish.config.json')).toString());
-  const sdk = await IronfishSdk.init(config);
+  const sdk = await IronfishSdk.init({ dataDir: '~/.dev0' });
   const client = await sdk.connectRpc();
 
   const response = await client.getAccountPublicKey({

--- a/content/documentation/integration_transactions.mdx
+++ b/content/documentation/integration_transactions.mdx
@@ -19,8 +19,7 @@ transactions (see docs
 
 ```js
 async function main(): Promise<void> {
-  const config = JSON.parse((await fsAsync.readFile('.ironfish.config.json')).toString());
-  const sdk = await IronfishSdk.init(config);
+  const sdk = await IronfishSdk.init({ dataDir: '~/.dev0' });
   const client = await sdk.connectRpc();
 
   const from = '<sending account>';
@@ -60,8 +59,7 @@ the mempool and broadcasted to the network (see docs
 
 ```js
 async function main(): Promise<void> {
-  const config = JSON.parse((await fsAsync.readFile('.ironfish.config.json')).toString());
-  const sdk = await IronfishSdk.init(config);
+  const sdk = await IronfishSdk.init({ dataDir: '~/.dev0' });
   const client = await sdk.connectRpc();
 
   const from = '<sending account>';


### PR DESCRIPTION
the 'IronfishSdk.init' examples in the integration guide use JSON config overrides read from a file, '.ironfish.config.json', but don't mention what is in that file.

a simpler approach to integration is to use the dataDir of the local node when initializing the SDK.

replaces config with dataDir in all sdk init examples