### PR TITLE
fixes incorrect rpc routes in docs

### DIFF
--- a/content/documentation/rpc_chain.mdx
+++ b/content/documentation/rpc_chain.mdx
@@ -53,7 +53,7 @@ undefined
 }
 ```
 
-## [chain/exportChain](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/chain/exportChain.ts)
+## [chain/exportChainStream](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/chain/exportChain.ts)
 
 Exports the chain as a stream of blocks. 
 
@@ -90,7 +90,7 @@ stop will be returned.
 }
 ```
 
-## [chain/followChain](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/chain/followChain.ts)
+## [chain/followChainStream](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/chain/followChain.ts)
 
 Follows the chain from a given sequence and streams blocks from chain connects and disconnects
 

--- a/content/documentation/rpc_wallet.mdx
+++ b/content/documentation/rpc_wallet.mdx
@@ -509,7 +509,7 @@ Posts a transaction, submitting it to the wallet, mempool, and network if possib
 }
 ```
 
-## wallet/removeAccount
+## wallet/remove
 
 Removes an account from the wallet.
 


### PR DESCRIPTION
fixes three incorrect rpc routes in which we use the name of TypeScript file that defines the logic for the route instead of the name of the route in the router:

- wallet/remove
- chain/exportChainStream
- chain/followChainStream