### PR TITLE
docs: add noteHash to response for wallet/getAccountNotesStream

### DIFF
--- a/content/documentation/rpc_wallet.mdx
+++ b/content/documentation/rpc_wallet.mdx
@@ -301,6 +301,7 @@ Returns a stream of notes in an account.
   assetName: string
   memo: string
   sender: string
+  noteHash: string
   transactionHash: string
   spent: boolean | undefined
 }


### PR DESCRIPTION
This is the docs update for https://github.com/iron-fish/ironfish/pull/3831