### PR TITLE
Remove RpcAccountDecryptedNote type from getAccountTransaction

### DIFF
--- a/content/documentation/rpc_wallet.mdx
+++ b/content/documentation/rpc_wallet.mdx
@@ -392,7 +392,16 @@ Gets a transaction for an account. If the account is not specified, the default 
     mintsCount: number
     burnsCount: number
     timestamp: number
-    notes: RpcAccountDecryptedNote[]
+    notes: Array<{
+      isOwner: boolean
+      value: string
+      assetId: string
+      assetName: string
+      memo: string
+      sender: string
+      owner: string
+      spent: boolean
+    }>
     assetBalanceDeltas: Array<{ 
       assetId: string
       assetName: string


### PR DESCRIPTION
The type isn't referenced anywhere in the docs that I can find, so we can expand it out. I think in the future it'd be useful to have a "types" page, and have each type link to the appropriate type on that page, though, to make it easier when updating the docs.

Fixes IFL-726
