### PR TITLE
fix: Scrolling to hash links

### DIFF
--- a/layouts/Documentation/Documentation.tsx
+++ b/layouts/Documentation/Documentation.tsx
@@ -5,8 +5,8 @@ import {
   SidebarMenu,
   MDXRenderer,
   useBreakpointValue,
-} from '@/lib/ui';
-import { ComponentProps } from 'react';
+} from "@/lib/ui";
+import { ComponentProps, useEffect } from "react";
 
 type SidebarItems = Array<
   | {
@@ -28,7 +28,7 @@ type Props = {
     title?: string;
     description?: string;
   };
-  markdown: ComponentProps<typeof MDXRenderer>['markdown'];
+  markdown: ComponentProps<typeof MDXRenderer>["markdown"];
   sidebarItems: SidebarItems;
   sidebarWidth?: string;
 };
@@ -37,7 +37,7 @@ export function DocumentationLayout({
   frontMatter,
   markdown,
   sidebarItems,
-  sidebarWidth = '235px',
+  sidebarWidth = "235px",
 }: Props) {
   const showOnThisPage = useBreakpointValue({
     base: false,
@@ -46,7 +46,7 @@ export function DocumentationLayout({
   return (
     <Grid
       templateColumns={{
-        base: '100%',
+        base: "100%",
         md: `${sidebarWidth} 1fr`,
         xl: `${sidebarWidth} auto ${sidebarWidth}`,
       }}

--- a/lib/ui/src/components/MDXRenderer/MDXRenderer.tsx
+++ b/lib/ui/src/components/MDXRenderer/MDXRenderer.tsx
@@ -15,30 +15,20 @@ import NextLink from "next/link";
 import { MDXProvider as BaseMDXProvider } from "@mdx-js/react";
 import { Terminal } from "../../components/Terminal/Terminal";
 import { FAQItem } from "../../components/FAQItem/FAQItem";
-import {
-  ReactNode,
-  ComponentProps,
-  useState,
-  useRef,
-  useLayoutEffect,
-  useEffect,
-} from "react";
+import { ReactNode, ComponentProps, useState, useCallback } from "react";
 import { kebabCase } from "lodash-es";
 import { useSmoothScrollToHash } from "../../hooks/useSmoothScrollToHash";
 
 function HeadingWithAnchor(props: ComponentProps<typeof Heading>) {
   const [headingId, setHeadingId] = useState("");
-  const ref = useRef<HTMLHeadingElement>(null);
-  useLayoutEffect(() => {
-    if (ref.current) {
-      const id = kebabCase(ref.current.textContent?.toLowerCase() || "");
-      setHeadingId(id);
-    }
+  const handleHeadingId = useCallback((ref: HTMLHeadingElement | null) => {
+    ref?.innerText && setHeadingId(kebabCase(ref.innerText.toLowerCase()));
   }, []);
+
   return (
     <Heading
       {...props}
-      ref={ref}
+      ref={handleHeadingId}
       id={headingId}
       fontWeight="normal"
       _hover={{

--- a/lib/ui/src/components/MDXRenderer/MDXRenderer.tsx
+++ b/lib/ui/src/components/MDXRenderer/MDXRenderer.tsx
@@ -15,13 +15,21 @@ import NextLink from "next/link";
 import { MDXProvider as BaseMDXProvider } from "@mdx-js/react";
 import { Terminal } from "../../components/Terminal/Terminal";
 import { FAQItem } from "../../components/FAQItem/FAQItem";
-import { ReactNode, ComponentProps, useState, useRef, useEffect } from "react";
+import {
+  ReactNode,
+  ComponentProps,
+  useState,
+  useRef,
+  useLayoutEffect,
+  useEffect,
+} from "react";
 import { kebabCase } from "lodash-es";
+import { useSmoothScrollToHash } from "../../hooks/useSmoothScrollToHash";
 
 function HeadingWithAnchor(props: ComponentProps<typeof Heading>) {
   const [headingId, setHeadingId] = useState("");
   const ref = useRef<HTMLHeadingElement>(null);
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (ref.current) {
       const id = kebabCase(ref.current.textContent?.toLowerCase() || "");
       setHeadingId(id);
@@ -115,7 +123,8 @@ const rendererComponents: ComponentProps<typeof MDXRemote>["components"] = {
 };
 
 function MDXRenderer({ markdown }: { markdown: MDXRemoteProps }) {
-  return <MDXRemote {...markdown} lazy components={rendererComponents} />;
+  useSmoothScrollToHash();
+  return <MDXRemote {...markdown} components={rendererComponents} />;
 }
 
 const providerComponents = {

--- a/lib/ui/src/hooks/useSmoothScrollToHash.ts
+++ b/lib/ui/src/hooks/useSmoothScrollToHash.ts
@@ -7,7 +7,8 @@ export function useSmoothScrollToHash() {
         window.location.hash && document.querySelector(window.location.hash);
       if (hashEl) {
         const headerOffset = 100;
-        const elementPosition = hashEl.getBoundingClientRect().top;
+        const elementPosition =
+          window.scrollY + hashEl.getBoundingClientRect().top;
         window.scrollTo({
           top: elementPosition - headerOffset,
           behavior: "smooth",

--- a/lib/ui/src/hooks/useSmoothScrollToHash.ts
+++ b/lib/ui/src/hooks/useSmoothScrollToHash.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+export function useSmoothScrollToHash() {
+  useEffect(() => {
+    setTimeout(() => {
+      const hashEl =
+        window.location.hash && document.querySelector(window.location.hash);
+      if (hashEl) {
+        const headerOffset = 100;
+        const elementPosition = hashEl.getBoundingClientRect().top;
+        window.scrollTo({
+          top: elementPosition - headerOffset,
+          behavior: "smooth",
+        });
+      }
+    }, 0);
+  }, []);
+}


### PR DESCRIPTION
Smooth scrolls to hash links when loading the markdown views.