### PR TITLE
Add example for combining multiple notes into one

### DIFF
--- a/content/documentation/integration_combining_notes.mdx
+++ b/content/documentation/integration_combining_notes.mdx
@@ -33,7 +33,7 @@ async function main(): Promise<void> {
 
   // Sum all unspent notes with the native asset ID 
   const fee = 10n;
-  const spendNoteHashes = [];
+  const notes = [];
   let noteTotal = 0n;
 
   const stream = client.wallet.getAccountNotesStream({
@@ -42,7 +42,7 @@ async function main(): Promise<void> {
 
   for await (const note of stream.contentStream()) {
     if (!note.spent && note.assetId === Asset.nativeId().toString('hex')) {
-      spendNoteHashes.push(note.noteHash);
+      notes.push(note.noteHash);
       noteTotal += BigInt(note.value);
     }
   }
@@ -59,10 +59,10 @@ async function main(): Promise<void> {
       },
     ],
     fee: CurrencyUtils.encode(fee),
-    spendNoteHashes,
+    notes,
   };
 
   const response = await client.wallet.createTransaction(options);
-  console.log(response);
+  console.log(response.content.transaction);
 }
 ```

--- a/content/documentation/integration_combining_notes.mdx
+++ b/content/documentation/integration_combining_notes.mdx
@@ -1,0 +1,68 @@
+---
+title: Combining Notes
+description: Integration Guide | Combining Notes | Iron Fish Documentation
+---
+
+Each note spent in a transaction consumes space in the transaction and increases the time it
+takes to post the transaction. As such, it can be useful to create transactions that combine smaller
+notes into larger notes.
+
+Here's an example that combines all the $IRON notes in an account into a single note.
+
+```js
+import { CreateTransactionRequest, CurrencyUtils, IronfishSdk } from '@ironfish/sdk'
+import { Asset } from '@ironfish/rust-nodejs'
+
+async function main(): Promise<void> {
+  const sdk = await IronfishSdk.init({ dataDir: '~/.dev0' });
+  const client = await sdk.connectRpc();
+
+  // Fetch an account to combine notes
+  const defaultAccountResponse = await client.wallet.getDefaultAccount();
+  if (defaultAccountResponse.content.account === null) {
+    throw new Error('Expected a default account')
+  }
+
+  const accountName = defaultAccountResponse.content.account.name
+
+  const accountResponse = await client.wallet.getAccountPublicKey({
+    account: accountName
+  })
+
+  const publicAddress = accountResponse.content.publicKey
+
+  // Sum all unspent notes with the native asset ID 
+  const fee = 10n;
+  const spendNoteHashes = [];
+  let noteTotal = 0n;
+
+  const stream = client.wallet.getAccountNotesStream({
+    account: accountName,
+  });
+
+  for await (const note of stream.contentStream()) {
+    if (!note.spent && note.assetId === Asset.nativeId().toString('hex')) {
+      spendNoteHashes.push(note.noteHash);
+      noteTotal += BigInt(note.value);
+    }
+  }
+
+  // Create the transaction 
+  const options: CreateTransactionRequest = {
+    account: accountName,
+    outputs: [
+      {
+        publicAddress,
+        amount: CurrencyUtils.encode(noteTotal - fee),
+        memo: '',
+        assetId: Asset.nativeId().toString('hex'),
+      },
+    ],
+    fee: CurrencyUtils.encode(fee),
+    spendNoteHashes,
+  };
+
+  const response = await client.wallet.createTransaction(options);
+  console.log(response);
+}
+```

--- a/content/documentation/sidebar.ts
+++ b/content/documentation/sidebar.ts
@@ -25,6 +25,7 @@ export const sidebar: SidebarDefinition = [
       "integration_keys",
       "integration_transactions",
       "integration_deposits",
+      "integration_combining_notes",
     ],
   },
   "offline-transaction-signing",


### PR DESCRIPTION
It can be useful to combine notes into one to reduce the proving time and transaction size on actual transactions. This includes an example using the updated createTransaction API that takes note hashes.

Fixes IFL-716
