### PR TITLE
Fix links to Github RPC code

### DIFF
--- a/content/documentation/rpc_chain.mdx
+++ b/content/documentation/rpc_chain.mdx
@@ -75,7 +75,7 @@ undefined
 }
 ```
 
-## [chain/exportChainStream](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/chain/exportChain.ts)
+## [chain/exportChainStream](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/chain/exportChainStream.ts)
 
 Exports the chain as a stream of blocks. 
 
@@ -112,7 +112,7 @@ stop will be returned.
 }
 ```
 
-## [chain/followChainStream](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/chain/followChain.ts)
+## [chain/followChainStream](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/chain/followChainStream.ts)
 
 Follows the chain from a given sequence and streams blocks from chain connects and disconnects
 

--- a/content/documentation/rpc_event.mdx
+++ b/content/documentation/rpc_event.mdx
@@ -3,7 +3,7 @@ title: Event RPCs
 description: RPC Event | Iron Fish Documentation
 ---
 
-## [event/onGossip](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/events/onGossip.ts)
+## [event/onGossip](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/event/onGossip.ts)
 
 Streams block headers on gossip events
 

--- a/content/documentation/rpc_miner.mdx
+++ b/content/documentation/rpc_miner.mdx
@@ -3,7 +3,7 @@ title: Miner RPCs
 description: RPC Miner | Iron Fish Documentation
 ---
 
-## [miner/blockTemplateStream](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/mining/blockTemplateStream.ts)
+## [miner/blockTemplateStream](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/miner/blockTemplateStream.ts)
 
 Streams block templates from the chain for mining blocks
 
@@ -35,7 +35,7 @@ undefined
 }
 ```
 
-## [miner/submitBlock](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/mining/submitBlock.ts)
+## [miner/submitBlock](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/miner/submitBlock.ts)
 
 Submit a block template to the mining manager
 

--- a/content/documentation/rpc_peer.mdx
+++ b/content/documentation/rpc_peer.mdx
@@ -3,7 +3,7 @@ title: Peer RPCs
 description: RPC Peer | Iron Fish Documentation
 ---
 
-## [peer/getBannedPeers](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/peers/getBannedPeers.ts)
+## [peer/getBannedPeers](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/peer/getBannedPeers.ts)
 
 Gets (and optionally streams) banned peers from the node's peer network
 
@@ -26,7 +26,7 @@ Gets (and optionally streams) banned peers from the node's peer network
 }
 ```
 
-## [peer/getPeer](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/peers/getPeer.ts)
+## [peer/getPeer](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/peer/getPeer.ts)
 
 Gets (and optionally streams) peer data from an identity
 
@@ -81,7 +81,7 @@ Gets (and optionally streams) peer data from an identity
 }
 ```
 
-## [peer/getPeerMessages](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/peers/getPeerMessages.ts)
+## [peer/getPeerMessages](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/peer/getPeerMessages.ts)
 
 Gets (and optionally streams) peer messages from an identity
 
@@ -109,7 +109,7 @@ Gets (and optionally streams) peer messages from an identity
 }
 ```
 
-## [peer/getPeers](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/peers/getPeers.ts)
+## [peer/getPeers](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/peer/getPeers.ts)
 
 Gets (and optionally streams) peers from the node's peer network
 

--- a/content/documentation/rpc_wallet.mdx
+++ b/content/documentation/rpc_wallet.mdx
@@ -292,7 +292,7 @@ Gets the default account of the wallet.
 }
 ```
 
-## [wallet/getAccountNotesStream](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/getNotes.ts)
+## [wallet/getAccountNotesStream](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/getAccountNotesStream.ts)
 
 Streams the notes in the given account. If the account is not specified, the default account will be used.
 
@@ -341,7 +341,7 @@ Gets the public key of the given account. If the account is not specified, the d
 }
 ```
 
-## [wallet/getAccountStatus](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/getStatus.ts)
+## [wallet/getAccountStatus](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/getAccountStatus.ts)
 
 Gets the status of an account. If not specified, the status of all accounts are returned.
 
@@ -367,7 +367,7 @@ Gets the status of an account. If not specified, the status of all accounts are 
 }
 ```
 
-## [wallet/getAccountTransaction](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/getTransactions.ts)
+## [wallet/getAccountTransaction](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/getAccountTransaction.ts)
 
 Gets a transaction for an account. If the account is not specified, the default account is used.
 
@@ -423,7 +423,7 @@ Gets a transaction for an account. If the account is not specified, the default 
 }
 ```
 
-## [wallet/getAccountTransactions](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/getTransactions.ts)
+## [wallet/getAccountTransactions](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/getAccountTransactions.ts)
 
 Gets transactions for the given account. If not specified, the default account is used.
 
@@ -564,7 +564,7 @@ Posts a transaction and submits it to the wallet, mempool, and network if possib
 }
 ```
 
-## [wallet/remove](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/removeAccount.ts)
+## [wallet/remove](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/remove.ts)
 
 Removes an account from the wallet.
 
@@ -641,7 +641,7 @@ Creates a transaction, posts the transaction, and submits it to the wallet, memp
 }
 ```
 
-## [wallet/useAccount](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/useAccount.ts)
+## [wallet/useAccount](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/use.ts)
 
 Sets an account as the default account of the wallet.
 

--- a/content/documentation/rpc_worker.mdx
+++ b/content/documentation/rpc_worker.mdx
@@ -3,7 +3,7 @@ title: Worker RPCs
 description: RPC Worker | Iron Fish Documentation
 ---
 
-## [worker/getStatus](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/workers/getStatus.ts)
+## [worker/getStatus](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/worker/getStatus.ts)
 
 Gets (and optionally streams) the status of the long-running jobs queued by the node's workers. 
 The workers operate similar to a threadpool.


### PR DESCRIPTION
RPC files were renamed to match the routes they contain here: https://github.com/iron-fish/ironfish/pull/3837

This PR updates the links to the RPC files.