### PR TITLE
ifl-717: adds maximizing transaction size guide

### DIFF
--- a/content/documentation/integration_maximizing_transaction_size.mdx
+++ b/content/documentation/integration_maximizing_transaction_size.mdx
@@ -34,8 +34,8 @@ async function main(): Promise<void> {
   const sdk = await IronfishSdk.init({ dataDir: '~/.dev0' })
   const client = await sdk.connectRpc()
   // Get the max block size from the node
-  const concensusParams = await client.chain.getConsensusParameters()
-  const maxBlockSizeBytes = concensusParams.content.maxBlockSizeBytes
+  const consensusParams = await client.chain.getConsensusParameters()
+  const maxBlockSizeBytes = consensusParams.content.maxBlockSizeBytes
   let lengthGuess = outputs.length
   while (NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE * lengthGuess > maxBlockSizeBytes) {
     lengthGuess--

--- a/content/documentation/integration_maximizing_transaction_size.mdx
+++ b/content/documentation/integration_maximizing_transaction_size.mdx
@@ -19,6 +19,7 @@ import {
   IronfishSdk,
   RawTransactionSerde,
 } from '@ironfish/sdk'
+
 async function main(): Promise<void> {
   const sdk = await IronfishSdk.init({ dataDir: '~/.dev0' })
   const client = await sdk.connectRpc()

--- a/content/documentation/integration_maximizing_transaction_size.mdx
+++ b/content/documentation/integration_maximizing_transaction_size.mdx
@@ -1,0 +1,82 @@
+---
+title: Maximizing Transaction Size
+description: Integration Guide | Maximizing Transaction Size | Iron Fish Documentation
+---
+
+Iron Fish transactions, in their simplest form, spend notes to fund payments (plus the miners fee).
+The Iron Fish [block](/use/get-started/glossary#Block) has a predefined size limit, so there is a limit on the size and number of transactions in a block.
+In effect, if you are maximizing transaction size, you are trying to make the transaction size equal to the max
+block size.
+
+Here's an example that creates a transaction with a rough estimate of the number of notes that can fit in a block, then incrementally removes notes until the transaction will fit in a block.
+
+```js
+import { Asset } from '@ironfish/rust-nodejs'
+import {
+  CreateTransactionRequest,
+  CurrencyUtils,
+  IronfishSdk,
+  RawTransactionSerde,
+} from '@ironfish/sdk'
+import { NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE } from '@ironfish/sdk/src/primitives/noteEncrypted'
+async function main(): Promise<void> {
+  // creating fake outputs for example
+  const outputs: CreateTransactionRequest['outputs'] = []
+  for (let i = 0; i < 100000; i++) {
+    outputs.push({
+      publicAddress: 'd841fcda692fdc030e772037c27c5c8d57b4d55355f8636126f338b74d59de1c',
+      amount: CurrencyUtils.encode(1n),
+      memo: 'test',
+      assetId: Asset.nativeId().toString('hex'),
+    })
+  }
+
+  const sdk = await IronfishSdk.init({ dataDir: '~/.dev0' })
+  const client = await sdk.connectRpc()
+  // Get the max block size from the node
+  const concensusParams = await client.chain.getConsensusParameters()
+  const maxBlockSizeBytes = concensusParams.content.maxBlockSizeBytes
+  let lengthGuess = outputs.length
+  while (NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE * lengthGuess > maxBlockSizeBytes) {
+    lengthGuess--
+  }
+
+  console.log('Rough estimate of outputs fit in transaction: ', lengthGuess)
+  let options: CreateTransactionRequest = {
+    outputs: outputs.slice(0, lengthGuess),
+    account: 'DummyAccount',
+    feeRate: '200',
+  }
+  let response = await client.wallet.createTransaction(options)
+  let bytes = RawTransactionSerde.deserialize(
+    Buffer.from(response.content.transaction, 'hex'),
+  ).postedSize()
+  // keep recreating the transaction until it fits in the block
+  while (bytes > maxBlockSizeBytes) {
+    console.log(
+      `Transaction still too big, size (bytes): ${bytes}, trying ${lengthGuess - 1} outputs`,
+    )
+    lengthGuess--
+    options = {
+      outputs: outputs.slice(0, lengthGuess),
+      account: 'DummyAccount',
+      feeRate: '200',
+    }
+    response = await client.wallet.createTransaction(options)
+    bytes = RawTransactionSerde.deserialize(
+      Buffer.from(response.content.transaction, 'hex'),
+    ).postedSize()
+  }
+
+  // The greatest output number that creates a transaction with a byte size less than maxBlockSizeBytes
+  console.log(`Fit first ${lengthGuess} outputs in transaction, size (bytes): ${bytes}`)
+}
+```
+
+The corresponding console output:
+```
+Rough estimate of outputs fit in transaction:  1008
+Transaction still too big, size (bytes): 525177, trying 1007 outputs
+Transaction still too big, size (bytes): 524657, trying 1006 outputs
+Fit first 1006 outputs in transaction, size (bytes): 524137
+```

--- a/content/documentation/integration_maximizing_transaction_size.mdx
+++ b/content/documentation/integration_maximizing_transaction_size.mdx
@@ -3,12 +3,13 @@ title: Maximizing Transaction Size
 description: Integration Guide | Maximizing Transaction Size | Iron Fish Documentation
 ---
 
-Iron Fish transactions, in their simplest form, spend notes to fund payments (plus the miners fee).
-The Iron Fish [block](/use/get-started/glossary#Block) has a predefined size limit, so there is a limit on the size and number of transactions in a block.
-In effect, if you are maximizing transaction size, you are trying to make the transaction size equal to the max
-block size.
+Each spend, output, mint, and burn in an Iron Fish transaction increases its size. The
+maximum size of a transaction is the maximum size of a [block](/use/get-started/glossary#Block)
+minus the size of the block's header and miner's fee transaction.
 
-Here's an example that creates a transaction with a rough estimate of the number of notes that can fit in a block, then incrementally removes notes until the transaction will fit in a block.
+This example creates a maximum-size transaction. In practice, you may want to specify
+which notes are spent in the transaction to maximize the number of outputs and set a
+lower transaction size limit to avoid competing for block space with other transactions.
 
 ```js
 import { Asset } from '@ironfish/rust-nodejs'
@@ -18,65 +19,71 @@ import {
   IronfishSdk,
   RawTransactionSerde,
 } from '@ironfish/sdk'
-import { NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE } from '@ironfish/sdk/src/primitives/noteEncrypted'
 async function main(): Promise<void> {
-  // creating fake outputs for example
+  const sdk = await IronfishSdk.init({ dataDir: '~/.dev0' })
+  const client = await sdk.connectRpc()
+
+  // Fetch an account
+  const defaultAccountResponse = await client.wallet.getDefaultAccount()
+  if (defaultAccountResponse.content.account === null) {
+    throw new Error('Expected a default account')
+  }
+
+  const accountName = defaultAccountResponse.content.account.name
+
+  const accountResponse = await client.wallet.getAccountPublicKey({
+    account: accountName,
+  })
+
+  const publicAddress = accountResponse.content.publicKey
+
+  // TODO: The SDK should export this value so users don't have to hardcode it
+  const NOTE_ENCRYPTED_BYTES = 520
+
+  // Get the max transaction size from the node
+  // TODO: This value should subtract the header + miner fee from the max block size
+  const consensusParams = await client.chain.getConsensusParameters()
+  const maxTransactionSizeBytes = consensusParams.content.maxBlockSizeBytes
+  console.log('Max transaction size (bytes):', maxTransactionSizeBytes)
+
+  // Create some example outputs
+  let numOfOutputs = Math.floor(maxTransactionSizeBytes / NOTE_ENCRYPTED_BYTES)
+  console.log('Rough estimate of how many outputs can fit in a transaction:', numOfOutputs)
+
   const outputs: CreateTransactionRequest['outputs'] = []
-  for (let i = 0; i < 100000; i++) {
+  for (let i = 0; i < numOfOutputs; i++) {
     outputs.push({
-      publicAddress: 'd841fcda692fdc030e772037c27c5c8d57b4d55355f8636126f338b74d59de1c',
+      publicAddress,
       amount: CurrencyUtils.encode(1n),
       memo: 'test',
       assetId: Asset.nativeId().toString('hex'),
     })
   }
 
-  const sdk = await IronfishSdk.init({ dataDir: '~/.dev0' })
-  const client = await sdk.connectRpc()
-  // Get the max block size from the node
-  const consensusParams = await client.chain.getConsensusParameters()
-  const maxBlockSizeBytes = consensusParams.content.maxBlockSizeBytes
-  let lengthGuess = outputs.length
-  while (NOTE_ENCRYPTED_SERIALIZED_SIZE_IN_BYTE * lengthGuess > maxBlockSizeBytes) {
-    lengthGuess--
-  }
+  // Recreate the raw transaction until it fits in the block
+  let bytes = Infinity
+  let spends = Infinity
+  while (bytes > maxTransactionSizeBytes) {
+    console.log(`Calculating size of transaction with ${numOfOutputs} outputs...`)
 
-  console.log('Rough estimate of outputs fit in transaction: ', lengthGuess)
-  let options: CreateTransactionRequest = {
-    outputs: outputs.slice(0, lengthGuess),
-    account: 'DummyAccount',
-    feeRate: '200',
-  }
-  let response = await client.wallet.createTransaction(options)
-  let bytes = RawTransactionSerde.deserialize(
-    Buffer.from(response.content.transaction, 'hex'),
-  ).postedSize()
-  // keep recreating the transaction until it fits in the block
-  while (bytes > maxBlockSizeBytes) {
-    console.log(
-      `Transaction still too big, size (bytes): ${bytes}, trying ${lengthGuess - 1} outputs`,
-    )
-    lengthGuess--
-    options = {
-      outputs: outputs.slice(0, lengthGuess),
-      account: 'DummyAccount',
+    const options: CreateTransactionRequest = {
+      outputs: outputs.slice(0, numOfOutputs),
+      account: accountName,
       feeRate: '200',
     }
-    response = await client.wallet.createTransaction(options)
-    bytes = RawTransactionSerde.deserialize(
+
+    const response = await client.wallet.createTransaction(options)
+    const rawTransaction = RawTransactionSerde.deserialize(
       Buffer.from(response.content.transaction, 'hex'),
-    ).postedSize()
+    )
+    bytes = rawTransaction.size()
+    spends = rawTransaction.spends.length
+
+    numOfOutputs--
   }
 
-  // The greatest output number that creates a transaction with a byte size less than maxBlockSizeBytes
-  console.log(`Fit first ${lengthGuess} outputs in transaction, size (bytes): ${bytes}`)
+  console.log(
+    `Fit ${numOfOutputs} outputs in a transaction with ${spends} spends. Transaction size (bytes): ${bytes}`,
+  )
 }
-```
-
-The corresponding console output:
-```
-Rough estimate of outputs fit in transaction:  1008
-Transaction still too big, size (bytes): 525177, trying 1007 outputs
-Transaction still too big, size (bytes): 524657, trying 1006 outputs
-Fit first 1006 outputs in transaction, size (bytes): 524137
 ```

--- a/content/documentation/sidebar.ts
+++ b/content/documentation/sidebar.ts
@@ -26,6 +26,7 @@ export const sidebar: SidebarDefinition = [
       "integration_transactions",
       "integration_deposits",
       "integration_combining_notes",
+      "integration_maximizing_transaction_size"
     ],
   },
   "offline-transaction-signing",


### PR DESCRIPTION
This is a naive implementation of creating the biggest transaction possible to fit in a block. There are many other approaches to do this, but this is likely the simplest and relatively quick.