### PR TITLE
updates mining page for testnet mining pool

### DIFF
--- a/content/get-started/mining.mdx
+++ b/content/get-started/mining.mdx
@@ -55,7 +55,7 @@ ironfish config:set blockGraffiti "<your graffiti here>"
 ```
 
 ## Join a mining pool
-You can join a mining pool in order to increase your chances of mining a block. Block rewards are typically split among miners based on their respective contributions. We also run a basic mining pool that anyone can join. To get started, retrieve the public key of the account you want to use:
+You can join a mining pool in order to increase your chances of mining a block. Block rewards are typically split among miners based on their respective contributions. We also run a basic mining pool on testnet that anyone can join. To get started, retrieve the public key of the account you want to use:
 
 
 ```sh
@@ -66,7 +66,7 @@ And use that public key to join the mining pool:
 
 
 ```sh
-ironfish miners:start --pool pool.ironfish.network --address <PUBLIC KEY>
+ironfish miners:start --pool testnet.pool.ironfish.network --address <PUBLIC KEY>
 ```
 
 [Join our Discord](https://discord.ironfish.network) if you're interested in creating a different pool for Iron Fish.


### PR DESCRIPTION
we've shut down the mainnet mining pool.

updates hostname for pool to include 'tesetnet' and updates description of our pool to state that it's on testnet