### PR TITLE
docs: adds curl example for rpc (event, mempool, node) docs

### DIFF
--- a/content/documentation/rpc/event/on_gossip.mdx
+++ b/content/documentation/rpc/event/on_gossip.mdx
@@ -29,18 +29,30 @@ undefined
 ### Example
 ```bash
 # Request
-curl -X POST http://localhost:8021/event/onGossip
+curl -X POST -N http://localhost:8021/event/onGossip
 
 # Response
 {
   "data": {
     "blockHeader": {
-      "hash": "00000000000000218ecad25cc56a6d3906b9123b75eae21dc96a19e5af6c9755",
-      "sequence": 17656,
-      "previousBlockHash": "000000000000003378a17cff8aaec841879c50a1c12c8ae83f7bf0a55229a56b",
-      "timestamp": 1683063373270,
-      "difficulty": "266476277513883085",
-      "graffiti": "0000000000000000000000000000000000000000000000001f91951c00000000"
+      "hash": "000000000000000a8acaf500eb043758421e3de9ba0c3ac49e1dcc4c8d545d52",
+      "sequence": 18797,
+      "previousBlockHash": "000000000000001053c27bd149a65c6a2bb9d4d482a79e69e2962948279f1264",
+      "timestamp": 1683130257370,
+      "difficulty": "284365341300015620",
+      "graffiti": "00000000000000000000000066e58996ee4b41b852b9fb1443b6da1100000000"
+    }
+  }
+}
+{
+  "data": {
+    "blockHeader": {
+      "hash": "0000000000000023d753e3eb6e6b3cfca4293ba39363328715f2917d95b95bdf",
+      "sequence": 18798,
+      "previousBlockHash": "000000000000000a8acaf500eb043758421e3de9ba0c3ac49e1dcc4c8d545d52",
+      "timestamp": 1683130325413,
+      "difficulty": "284226491035708972",
+      "graffiti": "5a4b576f726b312e37323638c553ef071c000000000000000000000000000000"
     }
   }
 }

--- a/content/documentation/rpc/event/on_gossip.mdx
+++ b/content/documentation/rpc/event/on_gossip.mdx
@@ -5,10 +5,10 @@ description: RPC Event | Iron Fish Documentation
 
 Streams block headers on gossip events
 
-#### Request
+#### Request Body
 
 ```js
-undefined;
+undefined
 ```
 
 #### Response
@@ -16,12 +16,32 @@ undefined;
 ```js
 {
   blockHeader: {
-    hash: string;
-    sequence: number;
-    previousBlockHash: string;
-    timestamp: number;
-    difficulty: string;
-    graffiti: string;
+    hash: string
+    sequence: number
+    previousBlockHash: string
+    timestamp: number
+    difficulty: string
+    graffiti: string
+  }
+}
+```
+
+### Example
+```bash
+# Request
+curl -X POST http://localhost:8021/event/onGossip
+
+# Response
+{
+  "data": {
+    "blockHeader": {
+      "hash": "00000000000000218ecad25cc56a6d3906b9123b75eae21dc96a19e5af6c9755",
+      "sequence": 17656,
+      "previousBlockHash": "000000000000003378a17cff8aaec841879c50a1c12c8ae83f7bf0a55229a56b",
+      "timestamp": 1683063373270,
+      "difficulty": "266476277513883085",
+      "graffiti": "0000000000000000000000000000000000000000000000001f91951c00000000"
+    }
   }
 }
 ```

--- a/content/documentation/rpc/mempool/get_status.mdx
+++ b/content/documentation/rpc/mempool/get_status.mdx
@@ -34,6 +34,13 @@ Gets (and optionally streams) the status of the mempool
 # Request
 curl -X POST http://localhost:8021/mempool/getStatus
 
+# Request (with streaming)
+curl -X POST -N http://localhost:8021/mempool/getStatus \
+-H 'Content-Type: application/json' \
+--data '{
+    "stream": true
+}'
+
 # Response
 {
   "status": 200,
@@ -50,6 +57,8 @@ curl -X POST http://localhost:8021/mempool/getStatus
     }
   }
 }
+
+
 ```
 
 

--- a/content/documentation/rpc/mempool/get_status.mdx
+++ b/content/documentation/rpc/mempool/get_status.mdx
@@ -5,7 +5,7 @@ description: RPC Mempool GetStatus | Iron Fish Documentation
 
 Gets (and optionally streams) the status of the mempool
 
-#### Request
+#### Request Body
 
 ```js
 {
@@ -17,16 +17,40 @@ Gets (and optionally streams) the status of the mempool
 
 ```js
 {
-  size: number;
-  sizeBytes: number;
-  maxSizeBytes: number;
-  evictions: number;
-  headSequence: number;
+  size: number
+  sizeBytes: number
+  maxSizeBytes: number
+  evictions: number
+  headSequence: number
   recentlyEvictedCache: {
-    size: number;
-    maxSize: number;
+    size: number
+    maxSize: number
   }
 }
 ```
+
+### Example
+```bash
+# Request
+curl -X POST http://localhost:8021/mempool/getStatus
+
+# Response
+{
+  "status": 200,
+  "data": {
+    "size": 19,
+    "sizeBytes": 487869,
+    "maxSizeBytes": 60000000,
+    "headSequence": 17556,
+    "evictions": 0,
+    "recentlyEvictedCache": {
+        "size": 0,
+        "maxSize": 60000,
+        "saturation": 0
+    }
+  }
+}
+```
+
 
 ### [View on Github](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/mempool/getStatus.ts)

--- a/content/documentation/rpc/mempool/get_transactions.mdx
+++ b/content/documentation/rpc/mempool/get_transactions.mdx
@@ -5,19 +5,34 @@ description: RPC Mempool GetTransactions | Iron Fish Documentation
 
 Streams transactions from the mempool. Transactions are streamed in case there are a large number of transactions in the mempool.
 
-The `MinMax` type specifies the the minimum and maximum range of the input parameter to filter the returned transactions.
+The filters specify the the minimum and maximum range of the input parameter to filter the returned transactions.
 For example, `feeRate={min: 30; max:60}` specifies that only transactions with `30 <= txn.feeRate <= 60` are returned.
 
-#### Request
+#### Request Body
 
 ```js
 {
   limit?: number
-  feeRate?: MinMax
-  fee?: MinMax
-  expiration?: MinMax
-  expiresIn?: MinMax
-  position?: MinMax
+  feeRate?: {
+    min: number
+    max: number
+  }
+  fee?: {
+    min: number
+    max: number
+  }
+  expiration?: {
+    min: number
+    max: number
+  }
+  expiresIn?: {
+    min: number
+    max: number
+  }
+  position?: {
+    min: number
+    max: number
+  }
 }
 ```
 
@@ -25,9 +40,35 @@ For example, `feeRate={min: 30; max:60}` specifies that only transactions with `
 
 ```js
 {
-  serializedTransaction: string;
-  position: number;
-  expiresIn: number;
+  serializedTransaction: string
+  position: number
+  expiresIn: number
+}
+```
+
+### Example
+```bash
+# Request
+curl -X POST 'http://localhost:8021/mempool/getTransactions' \
+-H 'Content-Type: application/json' \
+-d '{
+    "position": {
+        "min": 0,
+        "max": 10
+    },
+    "limit": 1
+}'
+
+# Response
+{
+  "data": {
+    "serializedTransaction": "0102000...",
+    "position": 0,
+    "expiresIn": 14
+  }
+}
+{
+  "status": 200
 }
 ```
 

--- a/content/documentation/rpc/node/get_log_stream.mdx
+++ b/content/documentation/rpc/node/get_log_stream.mdx
@@ -27,7 +27,7 @@ undefined
 
 ```bash
 # Request
-curl -X POST http://localhost:8021/node/getLogStream
+curl -X POST -N http://localhost:8021/node/getLogStream
 
 # Response
 {

--- a/content/documentation/rpc/node/get_log_stream.mdx
+++ b/content/documentation/rpc/node/get_log_stream.mdx
@@ -5,21 +5,39 @@ description: RPC Node | Iron Fish Documentation
 
 Streams logs from the node
 
-#### Request
+#### Request Body
 
 ```js
-undefined;
+undefined
 ```
 
 #### Response
 
 ```js
 {
-  level: string;
-  type: string;
-  tag: string;
-  args: string;
-  date: string;
+  level: string
+  type: string
+  tag: string
+  args: string
+  date: string
+}
+```
+
+### Example
+
+```bash
+# Request
+curl -X POST http://localhost:8021/node/getLogStream
+
+# Response
+{
+  "data": {
+    "level": "4",
+    "type": "debug",
+    "tag": "start:ironfishsdk:ironfishnode:peernetwork:peermanager:webrtcconnection",
+    "args": "[\"\\u001b[32mCONN\\u001b[39m WebRtc 2uHo+// STATE WAITING_FOR_IDENTITY -> CONNECTED\"]",
+    "date": "2023-05-02T19:48:39.664Z"
+  }
 }
 ```
 

--- a/content/documentation/rpc/node/get_status.mdx
+++ b/content/documentation/rpc/node/get_status.mdx
@@ -5,7 +5,7 @@ description: RPC Node | Iron Fish Documentation
 
 Gets (and optionally streams) the node's status
 
-#### Request
+#### Request Body
 
 ```js
 {
@@ -18,13 +18,13 @@ Gets (and optionally streams) the node's status
 ```js
 {
   node: {
-    status: 'started' | 'stopped' | 'error'
+    status: 'started' | 'stopped' | 'error'     
     version: string
-    git: string
-    nodeName: string
+    git: string                                 
+    nodeName: string                            
   }
   cpu: {
-    cores: number
+    cores: number 
     percentRollingAvg: number
     percentCurrent: number
   }
@@ -105,5 +105,101 @@ Gets (and optionally streams) the node's status
   }
 }
 ```
+
+### Example
+
+```bash
+# Request
+curl -X POST http://localhost:8021/node/getStatus
+
+# Response
+{
+  "status": 200,
+  "data": {
+    "peerNetwork": {
+      "peers": 1,
+      "isReady": true,
+      "inboundTraffic": 164.7915348665539,
+      "outboundTraffic": 492.89305662948544
+    },
+    "blockchain": {
+      "synced": true,
+      "head": {
+        "hash": "0000000011d7fab8c852b8ee547452fdc77a10bc55f2ac4b8487b252005cb3a7",
+        "sequence": 6013
+      },
+      "headTimestamp": 1678400569905,
+      "newBlockSpeed": 0
+    },
+    "node": {
+      "status": "started",
+      "version": "0.1.71",
+      "git": "src",
+      "nodeName": ""
+    },
+    "cpu": {
+      "cores": 10,
+      "percentRollingAvg": 5.094278042633619,
+      "percentCurrent": 7.5034068136272545
+    },
+    "memory": {
+      "heapMax": 4283089400,
+      "heapTotal": 63651840,
+      "heapUsed": 58443312,
+      "rss": 441401344,
+      "memFree": 2373255168,
+      "memTotal": 17179869184
+    },
+    "miningDirector": {
+      "status": "started",
+      "miners": 0,
+      "blocks": 0,
+      "blockGraffiti": "",
+      "newBlockTemplateSpeed": 0,
+      "newBlockTransactionsSpeed": 0
+    },
+    "memPool": {
+      "size": 0,
+      "sizeBytes": 0,
+      "maxSizeBytes": 60000000,
+      "evictions": 0,
+      "recentlyEvictedCache": {
+        "size": 0,
+        "maxSize": 60000
+      }
+    },
+    "blockSyncer": {
+      "status": "idle",
+      "syncing": {
+        "blockSpeed": 0,
+        "speed": 0,
+        "downloadSpeed": 0,
+        "progress": 1
+      }
+    },
+    "telemetry": {
+      "status": "stopped",
+      "pending": 0,
+      "submitted": 0
+    },
+    "workers": {
+      "started": true,
+      "workers": 6,
+      "executing": 0,
+      "queued": 0,
+      "capacity": 6,
+      "change": 0,
+      "speed": 0
+    },
+    "accounts": {
+      "head": {
+        "hash": "0000000011d7fab8c852b8ee547452fdc77a10bc55f2ac4b8487b252005cb3a7",
+        "sequence": -1
+      }
+    }
+  }
+}
+```
+
 
 ### [View on Github](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/node/getStatus.ts)

--- a/content/documentation/rpc/node/get_status.mdx
+++ b/content/documentation/rpc/node/get_status.mdx
@@ -18,13 +18,13 @@ Gets (and optionally streams) the node's status
 ```js
 {
   node: {
-    status: 'started' | 'stopped' | 'error'     
+    status: 'started' | 'stopped' | 'error'
     version: string
-    git: string                                 
-    nodeName: string                            
+    git: string
+    nodeName: string
   }
   cpu: {
-    cores: number 
+    cores: number
     percentRollingAvg: number
     percentCurrent: number
   }

--- a/content/documentation/rpc/node/stop_node.mdx
+++ b/content/documentation/rpc/node/stop_node.mdx
@@ -5,16 +5,27 @@ description: RPC Node | Iron Fish Documentation
 
 Shuts the node down
 
-#### Request
+#### Request Body
 
 ```js
-undefined;
+undefined
 ```
 
 #### Response
 
 ```js
-undefined;
+undefined
+```
+
+### Example
+```bash
+# Request
+curl -X POST http://localhost:8021/node/stopNode
+
+# Response
+{
+  "status": 200
+}
 ```
 
 ### [View on Github](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/node/stopNode.ts)


### PR DESCRIPTION
See title.

A follow-up PR will add cURL examples to the rest of the RPC docs

Part of ticket 699

Preview: https://website-git-holahula-docscurl-rpcs-ironfish.vercel.app/