### PR TITLE
feat(ifl-780): adds getMaxTransactionBytes usage in maximizing transaction size recipe

### DIFF
--- a/content/documentation/recipes_maximizing_transaction_size.mdx
+++ b/content/documentation/recipes_maximizing_transaction_size.mdx
@@ -18,6 +18,7 @@ import {
   CurrencyUtils,
   IronfishSdk,
   RawTransactionSerde,
+  Verifier,
 } from '@ironfish/sdk'
 
 async function main(): Promise<void> {
@@ -42,9 +43,8 @@ async function main(): Promise<void> {
   const NOTE_ENCRYPTED_BYTES = 520
 
   // Get the max transaction size from the node
-  // TODO: This value should subtract the header + miner fee from the max block size
   const consensusParams = await client.chain.getConsensusParameters()
-  const maxTransactionSizeBytes = consensusParams.content.maxBlockSizeBytes
+  const maxTransactionSizeBytes = Verifier.getMaxTransactionBytes(consensusParams.content.maxBlockSizeBytes)
   console.log('Max transaction size (bytes):', maxTransactionSizeBytes)
 
   // Create some example outputs


### PR DESCRIPTION
This uses the method from https://github.com/iron-fish/ironfish/pull/3869/files to get the max transaction size dynamically based on concensus params for current node.

Should not be shipped until PR above is in a release.