### PR TITLE
updates sdk examples to use rpc client namespaces

### DIFF
--- a/content/documentation/integration_deposits.mdx
+++ b/content/documentation/integration_deposits.mdx
@@ -25,7 +25,7 @@ async function main(): Promise<void> {
     head,
   };
 
-  const response = await client.getAccountTransactionsStream(options);
+  const response = await client.wallet.getAccountTransactionsStream(options);
   for await (const content of response.contentStream()) {
     console.log(content);
   }

--- a/content/documentation/integration_rpc.mdx
+++ b/content/documentation/integration_rpc.mdx
@@ -21,7 +21,7 @@ async function main(): Promise<void> {
   const sdk = await IronfishSdk.init({ dataDir: '~/.dev0' });
   const client = await sdk.connectRpc();
 
-  const response = await client.getAccountPublicKey({
+  const response = await client.wallet.getAccountPublicKey({
     account: '<account>',
   });
   console.log(response);

--- a/content/documentation/integration_transactions.mdx
+++ b/content/documentation/integration_transactions.mdx
@@ -46,7 +46,7 @@ async function main(): Promise<void> {
     confirmations,
   };
 
-  const response = await client.createTransaction(options);
+  const response = await client.wallet.createTransaction(options);
   console.log(response);
 }
 ```
@@ -74,7 +74,7 @@ async function main(): Promise<void> {
     broadcast,
   };
 
-  const response = await client.postTransaction(options);
+  const response = await client.wallet.postTransaction(options);
   console.log(response);
 }
 ```


### PR DESCRIPTION
we recently moved the rpc client methods into namespaces such that `client.createTransaction` is now `client.wallet.createTransaction`.

updates sdk examples in our docs that are missing namespaces.