### PR TITLE
Fix title of Appendix page

### DIFF
--- a/content/whitepaper/appendix.mdx
+++ b/content/whitepaper/appendix.mdx
@@ -1,5 +1,5 @@
 ---
-title: Introduction
+title: Appendix
 seo-title: A Detailed Appendix
 ---
 


### PR DESCRIPTION
### What changed?

The appendix page showed up in the sidebar as "Introduction". This updates the title to "Appendix".

- 

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
