### PR TITLE
updates wallet notes rpc documentation

### DIFF
--- a/content/documentation/rpc/wallet/get_account_notes_stream.mdx
+++ b/content/documentation/rpc/wallet/get_account_notes_stream.mdx
@@ -22,11 +22,13 @@ Streams the notes in the given account. If the account is not specified, the def
   assetName: string;
   memo: string;
   sender: string;
+  owner: string;
   noteHash: string;
   transactionHash: string;
-  spent: boolean | undefined;
-  index: number | undefined;
+  index: number | null;
+  nullifier: string | null;
+  spent: boolean;
 }
 ```
 
-### [View on Github](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/getNotes.ts)
+### [View on Github](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/getAccountNotesStream.ts)

--- a/content/documentation/rpc/wallet/get_notes.mdx
+++ b/content/documentation/rpc/wallet/get_notes.mdx
@@ -1,0 +1,54 @@
+---
+title: wallet/getNotes
+description: RPC Wallet | Iron Fish Documentation
+---
+
+Retrieves notes for the given account. If the account is not specified, the default account will be used.
+
+Supports cursor-based pagination using the `pageSize` and `pageCursor` request parameters.
+
+Supports filtering notes by any of the fields in the `filter` request parameter.
+
+#### Request
+
+```js
+{
+  account?: string
+  pageSize?: number
+  pageCursor?: string
+  filter?: {
+    value?: string;
+    assetId?: string;
+    memo?: string;
+    sender?: string;
+    noteHash?: string;
+    transactionHash?: string;
+    nullifier?: string;
+    spent?: boolean;
+    index?: number;
+  }
+}
+```
+
+#### Response
+
+```js
+{
+  notes: Array<{
+    value: string;
+    assetId: string;
+    assetName: string;
+    memo: string;
+    sender: string;
+    owner: string;
+    noteHash: string;
+    transactionHash: string;
+    index: number | null;
+    nullifier: string | null;
+    spent: boolean;
+  }>
+  nextPageCursor: string | null
+}
+```
+
+### [View on Github](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/getNotes.ts)

--- a/content/documentation/rpc/wallet/get_notes.mdx
+++ b/content/documentation/rpc/wallet/get_notes.mdx
@@ -5,7 +5,7 @@ description: RPC Wallet | Iron Fish Documentation
 
 Retrieves notes for the given account. If the account is not specified, the default account will be used.
 
-Supports cursor-based pagination using the `pageSize` and `pageCursor` request parameters.
+Supports cursor-based pagination using the `pageSize` and `pageCursor` request parameters. Use the `nextPageCursor` from a response as the value of `pageCursor` in the next request to retrieve the next page of notes.
 
 Supports filtering notes by any of the fields in the `filter` request parameter.
 

--- a/content/documentation/sidebar.ts
+++ b/content/documentation/sidebar.ts
@@ -241,6 +241,10 @@ export const sidebar: SidebarDefinition = [
             label: "getDefaultAccount",
           },
           {
+            id: "rpc/wallet/get_notes",
+            label: "getNotes",
+          },
+          {
             id: "rpc/wallet/get_public_key",
             label: "getPublicKey",
           },


### PR DESCRIPTION
### What changed?

adds documentation for wallet/getNotes endpoint added in v1.2.0

amends documentation of wallet/getAccountNotesStream
- adds response fileds for 'owner' and 'nullifier' added in v1.2.0
- fixes link to source code


---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
