### PR TITLE
Change "current" account to "default" account

### DIFF
--- a/content/get-started/cli-commands.mdx
+++ b/content/get-started/cli-commands.mdx
@@ -128,7 +128,7 @@ Starts a miner and subscribes to new blocks for the node. The node has to be syn
 ironfish miners:start
 ```
 
-Join a mining pool with your default account public address. 
+Join a mining pool with your default account public address.
 
 ```sh
 ironfish miners:start -p <ip-address-of-pool>
@@ -196,7 +196,7 @@ ironfish wallet:create MyNewAccount
 
 #### wallet:address
 
-Gets the current account's public key
+Gets the default account's public key
 
 ```sh
 ironfish wallet:address
@@ -210,7 +210,7 @@ ironfish wallet:address MyNewAccount
 
 #### wallet:balance
 
-Gets the current account's balance
+Gets the default account's balance
 
 ```sh
 ironfish wallet:balance
@@ -218,7 +218,7 @@ ironfish wallet:balance
 
 #### wallet:balances
 
-Gets the current account's balance for all assets
+Gets the default account's balance for all assets
 
 ```sh
 ironfish wallet:balances
@@ -232,7 +232,7 @@ ironfish wallet:balance -a MyNewAccount
 
 #### wallet:notes
 
-Gets the current account's notes
+Gets the default account's notes
 
 ```sh
 ironfish wallet:notes
@@ -246,7 +246,7 @@ ironfish wallet:notes -a MyNewAccount
 
 #### wallet:transactions
 
-Gets the current account's transactions
+Gets the default account's transactions
 
 ```sh
 ironfish wallet:transactions

--- a/content/get-started/wallet-commands.mdx
+++ b/content/get-started/wallet-commands.mdx
@@ -311,7 +311,7 @@ Find the transaction on https://explorer.ironfish.network/transaction/e032e78268
 />
 
 ### Send a transaction
-To send a transaction from the current account
+To send a transaction from the default account
 
 ```sh
 ironfish wallet:send
@@ -340,7 +340,7 @@ Find the transaction on https://explorer.ironfish.network/transaction/ee32e78268
 />
 
 ### View transactions
-To view transactions from the current account
+To view transactions from the default account
 
 ```sh
 ironfish wallet:transactions


### PR DESCRIPTION
### What changed?

- It's important we standardize on usage. Our CLI and most of the docs call this the default account. We shouldn't create new names for things which already have standard names.
