### PR TITLE
updates getNoteWitness docs for confirmations

### DIFF
--- a/content/documentation/rpc/chain/get_note_witness.mdx
+++ b/content/documentation/rpc/chain/get_note_witness.mdx
@@ -6,15 +6,21 @@ description: RPC Chain | Iron Fish Documentation
 Gets a witness (merkle path) to a specified note in the note merkle tree.
 This witness is necessary for creating a transaction that spends the note.
 
-This endpoint would primarily be used to construct transactions without using the Iron Fish wallet.
-The returned `treeSize` and `rootHash` values will always reference the note merkle tree state at the current HEAD of the chain.
-If the chain experiences a re-org and the referenced HEAD moves to a fork, this witness will no longer be usable in a transaction.
+This endpoint would primarily be used to construct transactions without using
+the Iron Fish wallet.
+
+The returned `treeSize` and `rootHash` values will always reference the note
+merkle tree state at `confirmations` blocks behind current HEAD of the chain. If
+no value is provided for `confirmations`, then the value from the node's
+configuration will be used.  If the chain experiences a re-org and that block
+moves to a fork, this witness will no longer be usable in a transaction.
 
 #### Request
 
 ```js
 {
   index: number;
+  confirmations?: number;
 }
 ```
 


### PR DESCRIPTION
### What changed?

adds the 'confirmations' request parameter to the 'chain/getNoteWitness' docs and changes the explanation to explain how confirmations affect the witness.

- 

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
