### PR TITLE
Change default documentation to local development

### DIFF
--- a/content/documentation/sidebar.ts
+++ b/content/documentation/sidebar.ts
@@ -2,6 +2,27 @@ import { SidebarDefinition } from "@/lib/markdown";
 
 export const sidebar: SidebarDefinition = [
   {
+    label: "Integration Guide",
+    items: [
+      "integration_local",
+      "integration_mining",
+      "integration_rpc",
+      "integration_keys",
+      "integration_transactions",
+      "integration_deposits",
+    ],
+  },
+  {
+    label: "Recipes",
+    items: [
+      "recipes_combining_notes",
+      "recipes_maximizing_transaction_size",
+      "recipes_splitting_notes",
+    ],
+  },
+  "release-versioning",
+  "offline-transaction-signing",
+  {
     label: "RPC API Reference",
     items: [
       {
@@ -289,25 +310,4 @@ export const sidebar: SidebarDefinition = [
       },
     ],
   },
-  {
-    label: "Integration Guide",
-    items: [
-      "integration_local",
-      "integration_mining",
-      "integration_rpc",
-      "integration_keys",
-      "integration_transactions",
-      "integration_deposits",
-    ],
-  },
-  {
-    label: "Recipes",
-    items: [
-      "recipes_combining_notes",
-      "recipes_maximizing_transaction_size",
-      "recipes_splitting_notes",
-    ],
-  },
-  "release-versioning",
-  "offline-transaction-signing",
 ];

--- a/next.config.js
+++ b/next.config.js
@@ -35,7 +35,7 @@ const nextConfig = {
       {
         source: "/developers/documentation",
         destination:
-          "/developers/documentation/rpc/chain/broadcast_transaction",
+          "/developers/documentation/integration_local",
         permanent: false,
       },
     ];


### PR DESCRIPTION
### What changed?

Made it so the default category isnt one single chain RPC. It is now "Local Development".

I wanted to expand RPC API but couldn't figure out how to do that. It'll be in a different PR anyway.