### PR TITLE
Remove careers references from internal pages

### DIFF
--- a/components/Company/Backers/Backers.tsx
+++ b/components/Company/Backers/Backers.tsx
@@ -74,32 +74,6 @@ export function Backers() {
           )}
         </Grid>
       </Container>
-      <Flex
-        alignItems={{
-          base: "stretch",
-          sm: "center",
-        }}
-        flexDirection={{
-          base: "column",
-          sm: "row",
-        }}
-        justifyContent="center"
-        gap={{
-          base: 6,
-          sm: 8,
-        }}
-      >
-        <ArrowButton
-          size="sm"
-          colorScheme="white"
-          as="a"
-          href="https://jobs.lever.co/ironfish"
-          rel="noreferrer"
-          target="_blank"
-        >
-          Careers
-        </ArrowButton>
-      </Flex>
     </Box>
   );
 }

--- a/content/faqs/faqs.mdx
+++ b/content/faqs/faqs.mdx
@@ -66,14 +66,6 @@ We are able to discuss and announce features that have defined release dates, or
 
 </FAQItem>
 
-<FAQItem title="Are you hiring?">
-
-Check out our [Careers page](https://jobs.lever.co/ironfish)! We're working with some of the most exciting tools in cryptography and decentralized systems to create a frictionless, internet-native global currency system.
-
-To try Iron Fish yourself, visit our Get Started Page.
-
-</FAQItem>
-
 <FAQItem title="Do you have a community I can join?">
 
 Yes! We have an active, welcoming [Discord channel](https://discord.ironfish.network). Join to stay up to date on Iron Fish news, and engage with fellow users and builders.


### PR DESCRIPTION
### What changed?

- Removes links to the careers page on internal pages

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
