### PR TITLE
Add optional 'read mode' link to ecosystem items

### DIFF
--- a/content/ecosystem/ecosystem.ts
+++ b/content/ecosystem/ecosystem.ts
@@ -12,6 +12,7 @@ export const ECOSYSTEM: Array<{
   name: string;
   link: string;
   image: string;
+  highlight?: string;
 }> = [
   {
     type: "Tools",
@@ -48,6 +49,7 @@ export const ECOSYSTEM: Array<{
     name: "Hpool",
     link: "https://www.hpool.in/statistics/ironfish",
     image: "/images/ecosystem/hpool.png",
+    highlight: "/learn/blog/2022-12-08-Ecosystem-spotlight-Hpool",
   },
   {
     type: "Mining Pools",
@@ -150,6 +152,7 @@ export const ECOSYSTEM: Array<{
     name: "FoxWallet",
     link: "https://foxwallet.com/",
     image: "/images/ecosystem/fox-wallet.png",
+    highlight: "/learn/blog/2023-06-08-foxwallet-spotlight",
   },
   {
     type: "Wallets",

--- a/lib/ui/src/components/ArrowButton/ArrowButton.tsx
+++ b/lib/ui/src/components/ArrowButton/ArrowButton.tsx
@@ -11,25 +11,29 @@ import { FancyArrowRight } from "../../icons";
 type Props = Omit<ButtonProps, "size" | "colorScheme"> & {
   size?: "sm" | "lg";
   colorScheme?: "pink" | "white";
-  tilted?: boolean;
+  arrowStyle?: "right" | "tilted" | "hidden";
 };
 
 export const ArrowButton: ChakraComponent<"button", Props> = ({
   children,
   size = "lg",
   colorScheme = "pink",
-  tilted,
+  arrowStyle = "right",
   ...rest
 }: Props) => {
+  const isArrowTilted = arrowStyle === "tilted";
+  const isArrowHidden = arrowStyle === "hidden";
+
   const gap = useMemo(() => {
-    if (size === "sm") return tilted ? 1 : 2;
-    if (size === "lg") return tilted ? 2 : 4;
-  }, [size, tilted]);
+    if (size === "sm") return isArrowTilted ? 1 : 2;
+    if (size === "lg") return isArrowTilted ? 2 : 4;
+  }, [size, isArrowTilted]);
   const arrowTransform = useMemo(() => {
     if (size === "sm")
-      return tilted ? "rotate(-45deg) scale(0.65)" : "scale(0.8)";
-    if (size === "lg") return tilted ? "rotate(-45deg) scale(0.8)" : "scale(1)";
-  }, [size, tilted]);
+      return isArrowTilted ? "rotate(-45deg) scale(0.65)" : "scale(0.8)";
+    if (size === "lg")
+      return isArrowTilted ? "rotate(-45deg) scale(0.8)" : "scale(1)";
+  }, [size, isArrowTilted]);
   const py = useMemo(() => {
     if (size === "sm") return 4;
     if (size === "lg") return undefined;
@@ -55,12 +59,14 @@ export const ArrowButton: ChakraComponent<"button", Props> = ({
       py={py}
       {...colorStyles}
       {...rest}
-      pr={tilted ? 2 : undefined}
+      pr={isArrowTilted ? 2 : undefined}
     >
-      <Box mr={gap}>{children}</Box>
-      <Box transform={arrowTransform}>
-        <FancyArrowRight />
-      </Box>
+      <Box mr={isArrowHidden ? 0 : gap}>{children}</Box>
+      {arrowStyle !== "hidden" && (
+        <Box transform={arrowTransform}>
+          <FancyArrowRight />
+        </Box>
+      )}
     </Button>
   );
 };

--- a/pages/use/ecosystem/index.tsx
+++ b/pages/use/ecosystem/index.tsx
@@ -1,4 +1,5 @@
 import Head from "next/head";
+import Link from "next/link";
 import {
   Box,
   Container,
@@ -112,16 +113,28 @@ function Cards() {
                     {item.name}
                   </Text>
                   <ArrowButton
-                    tilted
                     as="a"
                     target="_blank"
                     rel="noreferrer"
                     href={item.link}
                     size="sm"
                     colorScheme="white"
+                    arrowStyle="tilted"
                   >
                     Visit
                   </ArrowButton>
+                  {item.highlight && (
+                    <ArrowButton
+                      as={Link}
+                      href={item.highlight}
+                      size="sm"
+                      colorScheme="white"
+                      arrowStyle="hidden"
+                      ml={3}
+                    >
+                      Read Mode
+                    </ArrowButton>
+                  )}
                 </Box>
               </ShadowBox>
             </GridItem>

--- a/pages/use/ecosystem/index.tsx
+++ b/pages/use/ecosystem/index.tsx
@@ -132,7 +132,7 @@ function Cards() {
                       arrowStyle="hidden"
                       ml={3}
                     >
-                      Read Mode
+                      Read More
                     </ArrowButton>
                   )}
                 </Box>


### PR DESCRIPTION
### What changed?

- Adds an optional "Read Mode" link to ecosystem items if a blog post link is provided

<img width="1276" alt="Screenshot 2023-06-08 at 11 49 46 PM" src="https://github.com/iron-fish/website/assets/3639170/7931dc7f-affd-40b8-89e0-8ddcff22d318">

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
