### PR TITLE
Remove mainnet migration instruction

### DIFF
--- a/content/get-started/installation.mdx
+++ b/content/get-started/installation.mdx
@@ -69,14 +69,6 @@ COMMANDS
   stop        Stop the node from running`}
 />
 
-### Migrate to Mainnet
-
-To make sure that your node is set up to run on mainnet use
-
-```sh
-ironfish mainnet
-```
-
 ### Update Iron Fish
 
 When new versions of Iron Fish are released, you can update through NPM:


### PR DESCRIPTION
### What changed?
We need to remove these instructions from the website now.