### PR TITLE
fix: Update broken docs links

### DIFF
--- a/content/documentation/integration_deposits.mdx
+++ b/content/documentation/integration_deposits.mdx
@@ -7,7 +7,7 @@ This section describes how to listen to incoming transactions and decrypting not
 
 ## Transaction Streams
 
-If your account is receiving transactions, you can use the Transaction Stream API (see [here](/developers/documentation/rpc_wallet#getAccountTransactions)).
+If your account is receiving transactions, you can use the Transaction Stream API (see [here](/developers/documentation/rpc/wallet/get_account_transactions)).
 
 ```js
 async function main(): Promise<void> {

--- a/content/documentation/integration_transactions.mdx
+++ b/content/documentation/integration_transactions.mdx
@@ -15,7 +15,7 @@ parameters needed to create a transaction on the Iron Fish chain. These include
 notes to spend, output notes with recipients, assets to mint, assets to burn,
 and a transaction fee. The Iron Fish RPC server can be used to create raw
 transactions (see docs
-[here](/developers/documentation/rpc_wallet#createTransaction)):
+[here](/developers/documentation/rpc/wallet/create_transaction)):
 
 ```js
 async function main(): Promise<void> {
@@ -55,7 +55,7 @@ async function main(): Promise<void> {
 
 After raw transactions are created, they must be posted in order to be added to
 the mempool and broadcasted to the network (see docs
-[here](/developers/documentation/rpc_wallet#postTransaction)):
+[here](/developers/documentation/rpc/wallet/post_transaction)):
 
 ```js
 async function main(): Promise<void> {


### PR DESCRIPTION
### What changed?

- Fixes a couple broken links in the docs

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
