### PR TITLE
adds documentation for event/onTransactionGossip

### DIFF
--- a/content/documentation/rpc/event/on_transaction_gossip.mdx
+++ b/content/documentation/rpc/event/on_transaction_gossip.mdx
@@ -1,0 +1,36 @@
+---
+title: event/onTransactionGossip
+description: RPC Event | Iron Fish Documentation
+---
+
+Streams serialized transactions on gossip events
+
+#### Request Body
+
+```js
+undefined
+```
+
+#### Response
+
+```js
+{
+  serializedTransaction: string
+}
+```
+
+### Example
+```bash
+# Request
+curl -X POST -N http://localhost:8021/event/onTransactionGossip
+
+# Response
+{
+  "data":
+    {
+      "serializedTransaction": "01010000...e931fd04"
+    }
+}
+```
+
+### [View on Github](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/event/onTransactionGossip.ts)

--- a/content/documentation/rpc/event/on_transaction_gossip.mdx
+++ b/content/documentation/rpc/event/on_transaction_gossip.mdx
@@ -26,10 +26,9 @@ curl -X POST -N http://localhost:8021/event/onTransactionGossip
 
 # Response
 {
-  "data":
-    {
-      "serializedTransaction": "01010000...e931fd04"
-    }
+  "data": {
+    "serializedTransaction": "01010000...e931fd04"
+  }
 }
 ```
 

--- a/content/documentation/sidebar.ts
+++ b/content/documentation/sidebar.ts
@@ -125,6 +125,15 @@ export const sidebar: SidebarDefinition = [
         ],
       },
       {
+        label: "Event",
+        items: [
+          {
+            id: "rpc/event/on_transaction_gossip",
+            label: "onTransactionGossip",
+          },
+        ],
+      },
+      {
         label: "Faucet",
         items: [
           {

--- a/content/documentation/sidebar.ts
+++ b/content/documentation/sidebar.ts
@@ -122,11 +122,6 @@ export const sidebar: SidebarDefinition = [
             id: "rpc/event/on_reorganize_chain",
             label: "onReorganizeChain",
           },
-        ],
-      },
-      {
-        label: "Event",
-        items: [
           {
             id: "rpc/event/on_transaction_gossip",
             label: "onTransactionGossip",


### PR DESCRIPTION
### What changed?

- adds a page to the website docs for the event/onTransactionGossip RPC endpoint

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
