### PR TITLE
adds documentation for event/onReorganizeChain

### DIFF
--- a/content/documentation/rpc/event/on_reorganize_chain.mdx
+++ b/content/documentation/rpc/event/on_reorganize_chain.mdx
@@ -1,0 +1,83 @@
+---
+title: event/onReorganizeChain
+description: RPC Event | Iron Fish Documentation
+---
+
+Streams block headers when the chain reorganizes from a fork. `oldHead` is the
+head of the chain before the reorg, `newHead` is the head of the chain after the
+reorg, and `fork` is the header for the block at which the two forks diverged.
+
+#### Request Body
+
+```js
+undefined
+```
+
+#### Response
+
+```js
+{
+  oldHead: {
+    hash: string
+    sequence: number
+    previousBlockHash: string
+    timestamp: number
+    difficulty: string
+    graffiti: string
+  }
+  newHead: {
+    hash: string
+    sequence: number
+    previousBlockHash: string
+    timestamp: number
+    difficulty: string
+    graffiti: string
+  }
+  fork: {
+    hash: string
+    sequence: number
+    previousBlockHash: string
+    timestamp: number
+    difficulty: string
+    graffiti: string
+  }
+}
+```
+
+### Example
+```bash
+# Request
+curl -X POST -N http://localhost:8021/event/onReorganizeChain
+
+# Response
+{
+  "data": {
+    "oldHead": {
+      "hash": "00000030b706cf005ca5674db2302ef3730cd249de0d8863de88292000f7c54d",
+      "sequence": 2086,
+      "previousBlockHash": "0000002fa93db186de8ff1638675c2fccc5dc36e9fd897a74182c434f4cadda5",
+      "timestamp": 1688076914718,
+      "difficulty": "50313867",
+      "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    "newHead": {
+      "hash": "0000001a42a0241e616e2b3a0c8901c15b6207d6ec8573ae8d0915d43a3514b3",
+      "sequence": 2085,
+      "previousBlockHash": "0000004788e98bb3f7c7b714a4f69b891b2cd72a3edf876c40882eb3f0bed76a",
+      "timestamp": 1688076888411,
+      "difficulty": "50240925",
+      "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    "fork": {
+      "hash": "0000004788e98bb3f7c7b714a4f69b891b2cd72a3edf876c40882eb3f0bed76a",
+      "sequence": 2084,
+      "previousBlockHash": "000000195fd83c2515a5f1e69cc80a0c57d38d43a749bc662ca373b15097c817",
+      "timestamp": 1688076705815,
+      "difficulty": "50537037",
+      "graffiti": "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  }
+}
+```
+
+### [View on Github](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/event/onReorganizeChain.ts)

--- a/content/documentation/sidebar.ts
+++ b/content/documentation/sidebar.ts
@@ -118,11 +118,6 @@ export const sidebar: SidebarDefinition = [
             id: "rpc/event/on_gossip",
             label: "onGossip",
           },
-        ],
-      },
-      {
-        label: "Event",
-        items: [
           {
             id: "rpc/event/on_reorganize_chain",
             label: "onReorganizeChain",

--- a/content/documentation/sidebar.ts
+++ b/content/documentation/sidebar.ts
@@ -121,6 +121,15 @@ export const sidebar: SidebarDefinition = [
         ],
       },
       {
+        label: "Event",
+        items: [
+          {
+            id: "rpc/event/on_reorganize_chain",
+            label: "onReorganizeChain",
+          },
+        ],
+      },
+      {
         label: "Faucet",
         items: [
           {


### PR DESCRIPTION
### What changed?

adds onReorganizeChain page to the RPC docs after https://github.com/iron-fish/ironfish/pull/3989

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
