### PR TITLE
Add documentation for followChainStream changes

### DIFF
--- a/content/documentation/rpc/chain/follow_chain_stream.mdx
+++ b/content/documentation/rpc/chain/follow_chain_stream.mdx
@@ -10,6 +10,7 @@ Follows the chain from a given sequence and streams blocks from chain connects a
 ```js
 {
   head?: string | null
+  serialized?: boolean
 } | undefined
 ```
 
@@ -32,6 +33,7 @@ Follows the chain from a given sequence and streams blocks from chain connects a
     work: string
     main: boolean
     transactions: Array<{
+      serialized?: string
       hash: string
       size: number
       fee: number
@@ -41,6 +43,8 @@ Follows the chain from a given sequence and streams blocks from chain connects a
       }>
       spends: Array<{
         nullifier: string
+        commitment: string
+        size: number
       }>
       mints: Array<{
         id: string


### PR DESCRIPTION
### What changed?
Adding serialized transaction to chain stream for external wallets and making Spend values more consistent with other RPC calls

- 

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
