### PR TITLE
Tweak governance nav item copy

### DIFF
--- a/shared/navLinks/messages.ts
+++ b/shared/navLinks/messages.ts
@@ -181,7 +181,7 @@ export const messages = defineMessages({
   },
   governanceDescription: {
     id: "nav.governanceDescription",
-    defaultMessage: "Discourse site for governance request for proposals.",
+    defaultMessage: "How the Iron Fish protocol is governed.",
   },
   grantsTitle: {
     id: "nav.grantsTitle",


### PR DESCRIPTION
### What changed?

- Updates governance item copy

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
