### PR TITLE
fix-typo-whitepaper-transactions

### DIFF
--- a/content/whitepaper/transaction.mdx
+++ b/content/whitepaper/transaction.mdx
@@ -63,7 +63,7 @@ The high level overview of the Spend description is that it spends a note by usi
 
 1. it is attempting to spend a note that the spender can decrypt
 2. this note exists in the Merkle Tree of Notes
-3. the _value commitment_ (**cm**) for that note was constructed using the true value of that note
+3. the _value commitment_ (**cv**) for that note was constructed using the true value of that note
 4. the revealed nullifier is the unique nullifier for that note and was constructed correctly
 5. the signature maps to the spender's authorization key
 


### PR DESCRIPTION


### What changed?

- fixed a typo for the abbreviation of value commitment from "cm" to the correct "cv" in the introductory bullet point.

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
