### PR TITLE
updates documentation of followChainStream with 'wait'

### DIFF
--- a/content/documentation/rpc/chain/follow_chain_stream.mdx
+++ b/content/documentation/rpc/chain/follow_chain_stream.mdx
@@ -3,7 +3,9 @@ title: chain/followChainStream
 description: RPC Chain | Iron Fish Documentation
 ---
 
-Follows the chain from a given sequence and streams blocks from chain connects and disconnects
+Follows the chain from a given sequence and streams blocks from chain connects
+and disconnects. If `wait` is set to false the stream will end when it reaches
+the head of the chain (true by default).
 
 #### Request
 
@@ -11,6 +13,7 @@ Follows the chain from a given sequence and streams blocks from chain connects a
 {
   head?: string | null
   serialized?: boolean
+  wait?: boolean
 } | undefined
 ```
 


### PR DESCRIPTION
### What changed?

adds 'wait' request parameter and description of its effect on the stream response

'wait' was added in https://github.com/iron-fish/ironfish/pull/4097


---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
