### PR TITLE
Update asset owner and creator fields following renames

### DIFF
--- a/content/documentation/rpc/chain/follow_chain_stream.mdx
+++ b/content/documentation/rpc/chain/follow_chain_stream.mdx
@@ -53,8 +53,9 @@ the head of the chain (true by default).
         id: string
         metadata: string
         name: string
-        owner: string
+        creator: string
         value: string
+        transferOwnershipTo: string | undefined
       }>
       burns: Array<{
         id: string

--- a/content/documentation/rpc/chain/get_asset.mdx
+++ b/content/documentation/rpc/chain/get_asset.mdx
@@ -21,6 +21,7 @@ Gets an asset from the blockchain from a given identifier
   id: string;
   metadata: string;
   name: string;
+  creator: string;
   owner: string;
   supply: string;
 }

--- a/content/documentation/rpc/wallet/get_assets.mdx
+++ b/content/documentation/rpc/wallet/get_assets.mdx
@@ -23,7 +23,7 @@ Streams all the assets in the wallet of the given account. If not specified, the
   metadata: string;
   nonce: number;
   name: string;
-  owner: string;
+  creator: string;
   status: string;
   supply: string | null;
   verification: {

--- a/content/documentation/rpc/wallet/get_balances.mdx
+++ b/content/documentation/rpc/wallet/get_balances.mdx
@@ -22,7 +22,7 @@ Gets the wallet's `$IRON` balance, as well as balances of custom assets of the g
   balances: Array<{
     assetId: string
     assetName: string
-    assetOwner: string
+    assetCreator: string
     assetVerification: {
       status: 'verified' | 'unverified' | 'unknown'
     }

--- a/content/get-started/wallet-commands.mdx
+++ b/content/get-started/wallet-commands.mdx
@@ -182,7 +182,7 @@ ironfish wallet:assets
 
 <Terminal command="ironfish wallet:assets"
   output={`
- Name     ID            Metadata               Status      Supply  Owner
+ Name     ID            Metadata               Status      Supply  Creator
  ──────── ───────────── ────────────────────── ─────────── ─────── ─────────────
  custom   89457...befb5 a custom asset         confirmed   42      89f22...a20ce
   `}


### PR DESCRIPTION
### What changed?

- Updated RPC fields that changed with the asset owner/creator changes

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>

Closes IFL-1405