### PR TITLE
adds documentation of wallet/estimateFeeRates

### DIFF
--- a/content/documentation/rpc/wallet/estimate_fee_rates.mdx
+++ b/content/documentation/rpc/wallet/estimate_fee_rates.mdx
@@ -1,0 +1,26 @@
+---
+title: wallet/estimateFeeRates
+description: RPC Wallet | Iron Fish Documentation
+---
+
+Estimates the fee rates for all priorities.
+
+See `chain/estimateFeeRate` to see how fee rates are estimated.
+
+#### Request
+
+```js
+undefined;
+```
+
+#### Response
+
+```js
+{
+  slow: string;
+  average: string;
+  fast: string;
+}
+```
+
+### [View on Github](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/estimateFeeRates.ts)

--- a/content/documentation/sidebar.ts
+++ b/content/documentation/sidebar.ts
@@ -234,6 +234,10 @@ export const sidebar: SidebarDefinition = [
             label: "createTransaction",
           },
           {
+            id: "rpc/wallet/estimate_fee_rates",
+            label: "estimateFeeRates",
+          },
+          {
             id: "rpc/wallet/export_account",
             label: "exportAccount",
           },


### PR DESCRIPTION
### What changed?

copies docs for chain/estimateFeeRates. the wallet endpoint is a proxy for the chain endpoint on the node that a wallet is connected to 

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
