### PR TITLE
adding nonce to getassets rpc endpoint

### DIFF
--- a/content/documentation/rpc/wallet/get_assets.mdx
+++ b/content/documentation/rpc/wallet/get_assets.mdx
@@ -21,6 +21,7 @@ Streams all the assets in the wallet of the given account. If not specified, the
   createdTransactionHash: string;
   id: string;
   metadata: string;
+  nonce: number;
   name: string;
   owner: string;
   status: string;


### PR DESCRIPTION
### What changed?

- A new `nonce` field was added to the `getAssets` endpoint

Changes in this PR: https://github.com/iron-fish/ironfish/pull/4178

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
