### PR TITLE
updates chain/getTransaction docs with mint name/metadata

### DIFF
--- a/content/documentation/rpc/chain/get_transaction.mdx
+++ b/content/documentation/rpc/chain/get_transaction.mdx
@@ -36,6 +36,8 @@ Gets a transaction from a block hash and transaction hash
   mints: Array<{
     assetId: string
     value: string
+    name: string
+    metadata: string
   }>
   burns: Array<{
     assetId: string


### PR DESCRIPTION
### What changed?

the name and metadata for each mint are now included in the responses of chain/getTransaction

see https://github.com/iron-fish/ironfish/pull/4143

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
