### PR TITLE
updates docs for wallet/getAccountsStatus: headInChain optional

### DIFF
--- a/content/documentation/rpc/wallet/get_accounts_status.mdx
+++ b/content/documentation/rpc/wallet/get_accounts_status.mdx
@@ -21,7 +21,7 @@ Gets the status of an account. If not specified, the status of all accounts are 
     name: string
     id: string
     headHash: string
-    headInChain: boolean
+    headInChain?: boolean
     sequence: string | number
   }>
 }


### PR DESCRIPTION
### What changed?

the headInChain response field is optional following https://github.com/iron-fish/ironfish/pull/4198

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
