### PR TITLE
Update our community link

### DIFF
--- a/shared/navLinks/messages.ts
+++ b/shared/navLinks/messages.ts
@@ -160,7 +160,7 @@ export const messages = defineMessages({
   },
   communityTitle: {
     id: "nav.communityTitle",
-    defaultMessage: "Our community",
+    defaultMessage: "Our Community",
   },
   communityDescription: {
     id: "nav.communityDescription",


### PR DESCRIPTION
### What changed?

Updates the text of the "Our Community" link to upper-case "Community" 

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
