### PR TITLE
updating documentation for running fullnode with no-wallet flag

### DIFF
--- a/content/get-started/cli-cmd-start.mdx
+++ b/content/get-started/cli-cmd-start.mdx
@@ -14,3 +14,15 @@ To start a full node with a different port and a different data directory
 ```sh
 ironfish start --port=9034 --datadir=~/.ironfish2/
 ```
+
+To disable the node's wallet
+
+```sh
+ironfish start --no-wallet
+```
+
+By appending the `--no-wallet` flag to the `start` command, the Iron Fish full node does not
+ - update your wallet's balance by decrypting notes
+ - track transactions from the blockchain in wallet
+
+The wallet uses CPU and system resources to run which may slow down your node. If you don't need a wallet you can disable it to make your validator run faster. This can be useful for miners running a block template node for a mining pool.

--- a/content/get-started/cli-cmd-wallet-notes.mdx
+++ b/content/get-started/cli-cmd-wallet-notes.mdx
@@ -36,6 +36,16 @@ To start a full node with a different port and a different data directory
 ironfish start --port=9034 --datadir=~/.ironfish2/
 ```
 
+To disable the full node's wallet
+
+```sh
+ironfish start --no-wallet
+```
+
+By appending the `--no-wallet` flag to the `start` command, the Iron Fish full node does not engage in wallet-related tasks such as transaction scanning and note decryption. This configuration can be useful in the following scenarios: 
+- Run the node without participating in wallet operations, preserving computational resources and enhancing performance for other tasks.
+- Run a separate standalone wallet node (coming soon)
+
 #### stop
 
 Stops the full node

--- a/content/get-started/cli-cmd-wallet-notes.mdx
+++ b/content/get-started/cli-cmd-wallet-notes.mdx
@@ -36,16 +36,6 @@ To start a full node with a different port and a different data directory
 ironfish start --port=9034 --datadir=~/.ironfish2/
 ```
 
-To disable the full node's wallet
-
-```sh
-ironfish start --no-wallet
-```
-
-By appending the `--no-wallet` flag to the `start` command, the Iron Fish full node does not engage in wallet-related tasks such as transaction scanning and note decryption. This configuration can be useful in the following scenarios: 
-- Run the node without participating in wallet operations, preserving computational resources and enhancing performance for other tasks.
-- Run a separate standalone wallet node (coming soon)
-
 #### stop
 
 Stops the full node


### PR DESCRIPTION
### What changed?

- a new `--no-wallet` flag for the ironfish start command

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
