### PR TITLE
Throw more useful errors when developing

### DIFF
--- a/lib/markdown/src/createSidebarItems.ts
+++ b/lib/markdown/src/createSidebarItems.ts
@@ -22,10 +22,18 @@ function buildSidebarItem(
   pathPrefix: string
 ): { title: string; href: string } {
   if (typeof item === "string") {
+    if (!contentMap[item]) {
+      throw new Error(`Sidebar references missing page ${item}`);
+    }
+
     return {
       title: contentMap[item].title,
       href: `${pathPrefix}/${contentMap[item].document}`,
     };
+  }
+
+  if (!contentMap[item.id]) {
+    throw new Error(`Sidebar references missing page ${item.id}`);
   }
 
   return {


### PR DESCRIPTION
When developing I constantly make mistakes in the side bar. This helps me know immedietly what page is missing when reorganizing the side bars. The existing error is just "undefined access".

**Before**
![Screenshot 2023-09-05 at 2 59 00 PM](https://github.com/iron-fish/website/assets/458976/3074d64c-8762-4d3e-a42a-844fb9afc17c)

**After**
![Screenshot 2023-09-05 at 2 58 34 PM](https://github.com/iron-fish/website/assets/458976/9bd4edf4-0948-43b2-9c62-562098b16c0d)

