### PR TITLE
Update rpc/wallet/create_transaction docs with transferOwnershipTo flag

### DIFF
--- a/content/documentation/rpc/wallet/create_transaction.mdx
+++ b/content/documentation/rpc/wallet/create_transaction.mdx
@@ -25,6 +25,7 @@ Creating a raw transaction does not require a spend key. They are not added to t
     name?: string
     metadata?: string
     value: string
+    transferOwnershipTo?: string
   }>
   burns?: Array<{
     assetId: string


### PR DESCRIPTION
### What changed?

- Added `transferOwnershipTo` flag

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
