### PR TITLE
feat: Add Text component to mdx

### DIFF
--- a/lib/ui/src/components/MDXRenderer/MDXRenderer.tsx
+++ b/lib/ui/src/components/MDXRenderer/MDXRenderer.tsx
@@ -7,6 +7,7 @@ import {
   ListItem,
   OrderedList,
   Text,
+  TextProps,
   UnorderedList,
   chakra,
 } from "@chakra-ui/react";
@@ -23,20 +24,6 @@ import { BlockQuote } from "../BlockQuote/BlockQuote";
 
 export function headingToAnchorId(headingEl: HTMLHeadingElement) {
   return kebabCase(headingEl.innerText.toLowerCase());
-}
-
-function Warning(props: ComponentProps<typeof Box>) {
-  return (
-    <Box
-      textAlign={"center"}
-      bg="#FEF8C3"
-      borderRadius="md"
-      color={"#7C7322"}
-      p={4}
-      mb={8}
-      {...props}
-    />
-  );
 }
 
 function HeadingWithAnchor(props: ComponentProps<typeof Heading>) {
@@ -145,7 +132,6 @@ const rendererComponents: ComponentProps<typeof MDXRemote>["components"] = {
       <Box as="table" {...props} {...DEFAULT_TEXT_PROPS} mb={8} />
     </Box>
   ),
-  Warning: (props) => <Warning>{props.children}</Warning>,
   blockquote: (props) => {
     return (
       <Box
@@ -157,6 +143,41 @@ const rendererComponents: ComponentProps<typeof MDXRemote>["components"] = {
       />
     );
   },
+};
+
+function Warning({ children }: { children: ReactNode }) {
+  return (
+    <Box
+      textAlign={"center"}
+      bg="#FEF8C3"
+      borderRadius="md"
+      color={"#7C7322"}
+      p={4}
+      mb={8}
+      sx={{
+        a: {
+          color: "#7C7322",
+          _visited: {
+            color: "#7C7322",
+          },
+        },
+        "*:last-child": {
+          mb: 0,
+        },
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+const providerComponents = {
+  Terminal,
+  FAQItem,
+  Img: (props: any) => <Image my={6} alt="" w="100%" {...props} />,
+  BlockQuote,
+  Warning,
+  Text: (props: TextProps) => <Text as="span" {...props} />,
 };
 
 function MDXRenderer({ markdown }: { markdown: MDXRemoteProps }) {
@@ -173,13 +194,6 @@ function MDXRenderer({ markdown }: { markdown: MDXRemoteProps }) {
     </>
   );
 }
-
-const providerComponents = {
-  Terminal,
-  FAQItem,
-  Img: (props: any) => <Image my={6} alt="" w="100%" {...props} />,
-  BlockQuote,
-};
 
 export function MDXProvider({ children }: { children: ReactNode }) {
   return (


### PR DESCRIPTION
### What changed?

- Adds Text component to MDX renderer
- Updates Warning component link color

Example:

```
### Balancing

<pre>
Spend(s)   :  cv  = <Text color='red'>v</Text>  * G<sub>v</sub> + <Text color='blueviolet'>rcv</Text>  * G<sub>rcv</sub>
Outputs(s) :  cv1 = <Text color='red'>v1</Text> * G<sub>v</sub> + <Text color='blueviolet'>rcv1</Text> * G<sub>rcv</sub>
Balance    :  <Text color='red'>v</Text> - <Text color='red'>v1</Text>
bvk        :  (<Text color='blueviolet'>rcv</Text> - <Text color='blueviolet'>rcv1</Text>) * G<sub>rcv</sub>
</pre>
```

Produces

<img width="849" alt="Screenshot 2023-09-27 at 3 02 27 PM" src="https://github.com/iron-fish/website/assets/3639170/6ff34225-5ce0-4c70-b9b2-8481fdbf999d">

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
