### PR TITLE
Rahul/ifl 1728 add chainfollowchainstream chaingetblock to block header

### DIFF
--- a/content/documentation/rpc/objects/rpcBlockHeader.mdx
+++ b/content/documentation/rpc/objects/rpcBlockHeader.mdx
@@ -28,3 +28,5 @@ Usage:
 - [chain/getTransactionStream](/developers/documentation/rpc/chain/get_transaction_stream)
 - [event/onGossip](/developers/documentation/rpc/event/on_gossip)
 - [event/onReorganizeChain](/developers/documentation/rpc/event/on_reorganize_chain)
+- [chain/followChainStream](/developers/documentation/rpc/chain/follow_chain_stream)
+- [chain/getBlock](/developers/documentation/rpc/chain/get_block)

--- a/content/documentation/sidebar.ts
+++ b/content/documentation/sidebar.ts
@@ -34,7 +34,7 @@ export const sidebar: SidebarDefinition = [
     items: [
       "rpc/protocol",
       {
-        label: "RPC Response Objects",
+        label: "Response Objects",
         items: [
           {
             id: "rpc/objects/rpcAccountAssetBalanceDelta",


### PR DESCRIPTION
### What changed?

- Adding chain/followchainstream and chain/getblock to the RpcBlockHeader usages

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
