### PR TITLE
fix(website): Remove back slashes

### DIFF
--- a/content/blog/2023-10-04-nfts-and-the-privacy-paradox.mdx
+++ b/content/blog/2023-10-04-nfts-and-the-privacy-paradox.mdx
@@ -6,23 +6,23 @@ image: /images/blog/nfts-and-the-privacy-paradox.png
 tags: [ironfish]
 ---
 
-NFTs have been under the spotlight for introducing a paradigm shift in how we think about ownership; enabling exciting opportunities for web3. However, with those opportunities come equally compelling privacy concerns. We're here to talk about those concerns and how Iron Fish stands as a solution, offering absolute privacy and compliance to the mitigated risks of the NFT privacy paradox. 
+NFTs have been under the spotlight for introducing a paradigm shift in how we think about ownership; enabling exciting opportunities for web3. However, with those opportunities come equally compelling privacy concerns. We're here to talk about those concerns and how Iron Fish stands as a solution, offering absolute privacy and compliance to the mitigated risks of the NFT privacy paradox.
 
 ## What is the Privacy Paradox?
 
-The Privacy Paradox in the context of NFTs, and to zoom out, blockchains in general, is the tension between the reality of transparency of the public ledger, and the simultaneous demand for user privacy and data protection. 
+The Privacy Paradox in the context of NFTs, and to zoom out, blockchains in general, is the tension between the reality of transparency of the public ledger, and the simultaneous demand for user privacy and data protection.
 
 ## Notable Concerns
 
-The urgent debate surrounding privacy in blockchains has been underscored by hundreds of millions of dollars being stolen or scammed in the PFP industry since the initial NFT bubble in 2021. The public association of NFTs with personal identities through social media platforms like X (formerly Twitter) is an ongoing security concern. The seemingly unbreaking trend of using your PFP as a digital avatar can directly link user's identities to their wallet addresses, making them easy targets for phishing scams. Even though best practices and secure wallets like Ledger Live exist, the complacency and lack of education around these measures can lead to devastating consequences.  \
+The urgent debate surrounding privacy in blockchains has been underscored by hundreds of millions of dollars being stolen or scammed in the PFP industry since the initial NFT bubble in 2021. The public association of NFTs with personal identities through social media platforms like X (formerly Twitter) is an ongoing security concern. The seemingly unbreaking trend of using your PFP as a digital avatar can directly link user's identities to their wallet addresses, making them easy targets for phishing scams. Even though best practices and secure wallets like Ledger Live exist, the complacency and lack of education around these measures can lead to devastating consequences.
 
 ## Privacy Concerns in NFTs beyond PFPs
 
 NFTs in sectors like real estate and healthcare are reshaping how we perceive and handle ownership and records. However, it brings forth privacy and security concerns that necessitate a re-evaluation of how information is stored and accessed on the blockchain.
 
-1. **Real Estate:** NFTs could simplify property ownership transactions by removing intermediaries. However, the transparent nature of blockchains could disclose sensitive details around these transactions, exposing the individuals involved to fraud, extortion or even physical harm in extreme cases. \
+1. **Real Estate:** NFTs could simplify property ownership transactions by removing intermediaries. However, the transparent nature of blockchains could disclose sensitive details around these transactions, exposing the individuals involved to fraud, extortion or even physical harm in extreme cases.
 2. **Healthcare:** NFTs offer notable benefits to healthcare by improving data accuracy, accessibility, and in-person security. Tokenizing medical records as NFTs could empower patients with control over their health records. However, the public ledger that is the blockchain can reveal extremely sensitive information while also breaking privacy and regulation standards.
-3. **Subscriptions**: NFTs can also enable subscriptions to services to token holders. For example, one could build a VPN subscription model such that an NFT holder could get access to that service, but not reveal anything else about themselves to the service provider. 
+3. **Subscriptions**: NFTs can also enable subscriptions to services to token holders. For example, one could build a VPN subscription model such that an NFT holder could get access to that service, but not reveal anything else about themselves to the service provider.
 
 The unforeseen exposure of sensitive information in these areas could lead to many challenges, including identity theft, fraud, and manipulation. A compromise in these areas could have severe, long-lasting effects on individuals, thus emphasizing the critical need for advanced security and privacy measures.
 


### PR DESCRIPTION
### What changed?

- Remove these back slashes
<img width="131" alt="Screenshot 2023-10-04 at 12 40 49 PM" src="https://github.com/iron-fish/website/assets/5459049/5f1b9af3-8843-430e-82c4-c58ddb16aadc">
<img width="814" alt="Screenshot 2023-10-04 at 12 40 59 PM" src="https://github.com/iron-fish/website/assets/5459049/7f85310f-14dc-46d0-8c31-733435f42013">

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
