### PR TITLE
Documentation: sort items in the node configuration table

### DIFF
--- a/content/get-started/node-configuration.mdx
+++ b/content/get-started/node-configuration.mdx
@@ -54,8 +54,8 @@ seo-title: Configure Your Node
 | poolDifficulty                    | The pool difficulty, which determines how often miners submit shares |
 | poolDiscordWebhook                | The discord webhook URL to post pool critical pool information to |
 | poolHost                          | The host that the pool is listening for miner connections on |
-| poolMaxConnectionsPerIp           | The maximum number of concurrent open connections per remote address |
 | poolLarkWebhook                   | The lark webhook URL to post pool critical pool information to |
+| poolMaxConnectionsPerIp           | The maximum number of concurrent open connections per remote address |
 | poolName                          | Name to use for mining pool (optional) |
 | poolPort                          | The port that the pool is listening for miner connections on |
 | poolRecentShareCutoff             | The length of time in seconds that will be used to calculate hashrate for the pool |
@@ -65,8 +65,8 @@ seo-title: Configure Your Node
 | rpcHttpPort                       | Port to connect to when establishing an RPC connection over HTTP |
 | rpcTcpHost                        | Address to connect to when establishing an RPC connection over TCP |
 | rpcTcpPort                        | Port to connect to when establishing an RPC connection over TCP |
-| tlsKeyPath                        | Private key path for TLS over TCP |
-| tlsCertPath                       | Node certificate path for authorizing TLS over TCP |
 | targetPeers                       | The ideal number of peers we'd like to be connected to. The node will attempt to establish new connections when below this number. |
 | telemetryApi                      | HTTP URL for the Telemetry API |
+| tlsCertPath                       | Node certificate path for authorizing TLS over TCP |
+| tlsKeyPath                        | Private key path for TLS over TCP |
 | transactionExpirationDelta        | The default delta of block sequence for which to expire transactions from the mempool |


### PR DESCRIPTION
I think this table is intended to be sorted alphabetically. A few items were out of order, so fixed that.