### PR TITLE
Remove broken Github wiki link

### DIFF
--- a/components/FaqMoreInfo/FaqMoreInfo.tsx
+++ b/components/FaqMoreInfo/FaqMoreInfo.tsx
@@ -14,12 +14,7 @@ export function FaqMoreInfo() {
       <Text textStyle="h5" textAlign="center">
         Don&apos;t see the answer to a question you have? Reach out to us on{" "}
         <TextLink href={CONSTANTS.SOCIAL_LINKS.twitter}>Twitter</TextLink> or{" "}
-        <TextLink href={CONSTANTS.SOCIAL_LINKS.discord}>Discord</TextLink>! You
-        can also check out our{" "}
-        <TextLink href={CONSTANTS.GITHUB_LINKS.wiki}>
-          community-run wiki
-        </TextLink>
-        .
+        <TextLink href={CONSTANTS.SOCIAL_LINKS.discord}>Discord</TextLink>!
       </Text>
     </Box>
   );

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -5,13 +5,8 @@ const SOCIAL_LINKS = {
   telegram: "https://t.me/ironfishcryptochat",
 };
 
-const GITHUB_LINKS = {
-  wiki: "https://github.com/iron-fish/ironfish/wiki",
-};
-
 export const CONSTANTS = {
   SOCIAL_LINKS,
-  GITHUB_LINKS,
 };
 
 export const GRANTS_FORM_URL =


### PR DESCRIPTION
### What changed?

Remove broken link because the Github wiki was removed

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
