### PR TITLE
Change NodeJS installation version to LTS

### DIFF
--- a/content/get-started/installation.mdx
+++ b/content/get-started/installation.mdx
@@ -5,7 +5,7 @@ seo-title: Installation
 
 ## Installing
 
-1. Install [Node.js 18 (on Windows, choose 64-bit/x64)](https://nodejs.org/en/download/).
+1. Install [Node.js LTS (on Windows, choose 64-bit/x64)](https://nodejs.org/en/download/).
 	- On Mac and Linux, You can also install Node.js through [nvm](https://nvm.sh/).
 	- On Windows, be sure to check "Also install required tools" during installation.
 	- On Linux, run the following to install the build-essential package:


### PR DESCRIPTION
### What changed?

This change allows us to avoid having to bump it every October. Or if we forgot, it would be confusing to people new to Iron Fish if they click through to the NodeJS download page and don't see version 18 (as is the case at the time of this commit)

Related PR: https://github.com/iron-fish/ironfish/pull/4395