### PR TITLE
Add Node App troubleshooting content

### DIFF
--- a/components/NodeApp/Download/Download.tsx
+++ b/components/NodeApp/Download/Download.tsx
@@ -8,7 +8,6 @@ import {
   ButtonProps,
   forwardRef,
   BoxProps,
-  Divider,
 } from "@/lib/ui";
 import { smoothScrollToElByQuerySelector } from "@/lib/ui/src/hooks/useSmoothScrollToHash";
 import {
@@ -78,6 +77,18 @@ export function DownloadForCurrentPlatform({ downloadUrlsByPlatform }: Props) {
           View All Download Options
         </Text>
       )}
+      <Text
+        mt={2}
+        as="button"
+        onClick={() => {
+          smoothScrollToElByQuerySelector("#node-app-faq");
+        }}
+        _hover={{
+          textDecoration: "underline",
+        }}
+      >
+        Having trouble? Check out the Node App FAQ
+      </Text>
     </Flex>
   );
 }

--- a/components/NodeApp/NodeAppFaqs/NodeAppFaqs.tsx
+++ b/components/NodeApp/NodeAppFaqs/NodeAppFaqs.tsx
@@ -1,11 +1,18 @@
 import { FaqMoreInfo } from "@/components/FaqMoreInfo/FaqMoreInfo";
-import { Container, FAQItem, Text, Box } from "@/lib/ui";
+import { Container, FAQItem, Text, Box, Link } from "@/lib/ui";
+import { CONSTANTS } from "@/shared/constants";
 
 export function NodeAppFaqs() {
   return (
     <Box borderBottom="1.5px solid black">
       <Container w="100%" maxW="container.xl" pt="150px">
-        <Text as="h2" textStyle="h3" mb={12} textAlign="center">
+        <Text
+          id="node-app-faq"
+          as="h2"
+          textStyle="h3"
+          mb={12}
+          textAlign="center"
+        >
           Node App FAQ
         </Text>
         <FAQItem title="Why opt in to telemetry?">
@@ -26,7 +33,33 @@ export function NodeAppFaqs() {
           mint/burn via the command line, but you can then access and transact
           with minted assets in the app.
         </FAQItem>
-
+        <FAQItem title="The app crashes on startup with the error: A JavaScript error occurred in the main process">
+          If you&apos;re on Windows and seeing this error, please install the
+          Visual C++ Redistributable and try again. You can download it from
+          Microsoft{" "}
+          <Link
+            isExternal
+            href="https://aka.ms/vs/17/release/vc_redist.x64.exe"
+            color="#3344dd"
+            _visited={{ color: "#884488" }}
+          >
+            right here
+          </Link>
+          .
+        </FAQItem>
+        <FAQItem title="Where can I ask for help with the Node App?">
+          If you have any questions or need additional help, you can talk to us
+          on about the Node App on{" "}
+          <Link
+            isExternal
+            href={CONSTANTS.SOCIAL_LINKS.discord}
+            color="#3344dd"
+            _visited={{ color: "#884488" }}
+          >
+            Discord
+          </Link>{" "}
+          in the #node-app channel.
+        </FAQItem>
         <FaqMoreInfo />
       </Container>
     </Box>

--- a/lib/ui/src/components/SidebarMenu/SidebarMenu.tsx
+++ b/lib/ui/src/components/SidebarMenu/SidebarMenu.tsx
@@ -125,7 +125,7 @@ function createNestedMenuItems(
     return (
       <Accordion
         key={item.title}
-        defaultIndex={isAccordionItemSelected ? 0 : undefined}
+        defaultIndex={0}
         allowToggle
         border="none"
         w="100%"


### PR DESCRIPTION
### What changed?

- Adds Windows troubleshooting FAQ item
- Adds FAQ item pointing people to Discord with more questions
- Adds link in the hero to get to the FAQ

<img width="1856" alt="Screenshot 2023-11-01 at 6 04 01 PM" src="https://github.com/iron-fish/website/assets/3639170/2d9718fa-a5d9-448a-988c-75275f7573e6">
<img width="1856" alt="Screenshot 2023-11-01 at 6 04 08 PM" src="https://github.com/iron-fish/website/assets/3639170/890fe91e-ae16-41a6-96d7-fd62665473a9">

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
