### PR TITLE
fix: 404 on Community Highlights link

### DIFF
--- a/components/Community/Join/Join.tsx
+++ b/components/Community/Join/Join.tsx
@@ -64,7 +64,7 @@ export function Join() {
         </ArrowButton>
         <ArrowButton
           as={Link}
-          href="/community/highlights"
+          href="/learn/blog?category=community-highlight"
           size="sm"
           colorScheme="white"
         >


### PR DESCRIPTION
### What changed?

- Fixes link to community contributions

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
