### PR TITLE
Update peer:add command to reflect waiting for result

### DIFF
--- a/content/documentation/rpc/peer/add_peer.mdx
+++ b/content/documentation/rpc/peer/add_peer.mdx
@@ -7,20 +7,20 @@ Attempts to connect to a peer through WebSockets using the given host and port. 
 
 #### Request
 
-```js
+```ts
 {
   host: string
-  port?: number
-  whitelist?: boolean
+  port: number | undefined
+  whitelist: boolean | undefined
 }
 ```
 
 #### Response
 
-```js
+```ts
 {
   added: boolean
-  error?: string
+  error: string | undefined
 }
 ```
 

--- a/content/documentation/rpc/peer/add_peer.mdx
+++ b/content/documentation/rpc/peer/add_peer.mdx
@@ -3,7 +3,7 @@ title: peer/addPeer
 description: RPC peer/addPeer | Iron Fish Documentation
 ---
 
-Attempts to connect to a peer through WebSockets using the given host and port. If whitelist is true (by default) the node will continue to attempt connections even if the initial connection fails
+Attempts to connect to a peer through WebSockets using the given host and port. The request waits for the result of the connection before returning. If whitelist is true (by default) the node will continue to attempt connections even if the initial connection fails
 
 #### Request
 
@@ -20,6 +20,7 @@ Attempts to connect to a peer through WebSockets using the given host and port. 
 ```js
 {
   added: boolean
+  error?: string
 }
 ```
 

--- a/content/documentation/sidebar.ts
+++ b/content/documentation/sidebar.ts
@@ -257,6 +257,10 @@ export const sidebar: SidebarDefinition = [
         label: "Peer",
         items: [
           {
+            id: "rpc/peer/add_peer",
+            label: "addPeer",
+          },
+          {
             id: "rpc/peer/get_banned_peers",
             label: "getBannedPeers",
           },
@@ -271,10 +275,6 @@ export const sidebar: SidebarDefinition = [
           {
             id: "rpc/peer/get_peer_messages",
             label: "getPeerMessages",
-          },
-          {
-            id: "rpc/peer/add_peer",
-            label: "addPeer",
           },
         ],
       },

--- a/content/documentation/sidebar.ts
+++ b/content/documentation/sidebar.ts
@@ -272,6 +272,10 @@ export const sidebar: SidebarDefinition = [
             id: "rpc/peer/get_peer_messages",
             label: "getPeerMessages",
           },
+          {
+            id: "rpc/peer/add_peer",
+            label: "addPeer",
+          },
         ],
       },
       {


### PR DESCRIPTION
### What changed?

`peer:add` command now waits for the connection result before returning. https://github.com/iron-fish/ironfish/pull/4448

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
