### PR TITLE
Format responses for typescript

### DIFF
--- a/content/documentation/rpc/chain/broadcast_transaction.mdx
+++ b/content/documentation/rpc/chain/broadcast_transaction.mdx
@@ -9,7 +9,7 @@ This is a one time broadcast. The transaction will not be rebroadcasted automati
 
 #### Request
 
-```js
+```ts
 {
   transaction: string;
 }
@@ -18,7 +18,7 @@ This is a one time broadcast. The transaction will not be rebroadcasted automati
 #### Response
 Returns accepted: true if the transaction was accepted into the node's mempool otherwise false.
 
-```js
+```ts
 {
   hash: string;
   accepted: boolean;

--- a/content/documentation/rpc/chain/estimate_fee_rate.mdx
+++ b/content/documentation/rpc/chain/estimate_fee_rate.mdx
@@ -15,7 +15,7 @@ The slow, average, and fast rates each come from a percentile in the distributio
 
 #### Request
 
-```js
+```ts
 {
   priority: 'slow' | 'average' | 'fast'
 } | undefined
@@ -23,7 +23,7 @@ The slow, average, and fast rates each come from a percentile in the distributio
 
 #### Response
 
-```js
+```ts
 {
   rate: string;
 }

--- a/content/documentation/rpc/chain/estimate_fee_rates.mdx
+++ b/content/documentation/rpc/chain/estimate_fee_rates.mdx
@@ -9,13 +9,13 @@ See `chain/estimateFeeRate` to see how fee rates are estimated.
 
 #### Request
 
-```js
+```ts
 undefined;
 ```
 
 #### Response
 
-```js
+```ts
 {
   slow: string;
   average: string;

--- a/content/documentation/rpc/chain/export_chain_stream.mdx
+++ b/content/documentation/rpc/chain/export_chain_stream.mdx
@@ -10,7 +10,7 @@ stop will be returned.
 
 #### Request
 
-```js
+```ts
 {
   start?: number | null
   stop?: number | null
@@ -19,7 +19,7 @@ stop will be returned.
 
 #### Response
 
-```js
+```ts
 {
   start: number
   stop: number

--- a/content/documentation/rpc/chain/follow_chain_stream.mdx
+++ b/content/documentation/rpc/chain/follow_chain_stream.mdx
@@ -9,7 +9,7 @@ the head of the chain (true by default).
 
 #### Request
 
-```js
+```ts
 {
   head?: string | null
   serialized?: boolean
@@ -19,7 +19,7 @@ the head of the chain (true by default).
 
 #### Response
 
-```js
+```ts
 {
   type: 'connected' | 'disconnected' | 'fork'
   head: {

--- a/content/documentation/rpc/chain/get_asset.mdx
+++ b/content/documentation/rpc/chain/get_asset.mdx
@@ -7,7 +7,7 @@ Gets an asset from the blockchain from a given identifier
 
 #### Request
 
-```js
+```ts
 {
   id: string;
 }
@@ -15,7 +15,7 @@ Gets an asset from the blockchain from a given identifier
 
 #### Response
 
-```js
+```ts
 RpcAsset
 ```
 

--- a/content/documentation/rpc/chain/get_block.mdx
+++ b/content/documentation/rpc/chain/get_block.mdx
@@ -9,7 +9,7 @@ One of hash or sequence must be provided.
 
 #### Request
 
-```js
+```ts
 {
   search?: string
   hash?: string
@@ -20,7 +20,7 @@ One of hash or sequence must be provided.
 
 #### Response
 
-```js
+```ts
 {
   block: RpcBlock
   metadata: {

--- a/content/documentation/rpc/chain/get_chain_info.mdx
+++ b/content/documentation/rpc/chain/get_chain_info.mdx
@@ -7,13 +7,13 @@ Gets information about the node's chain
 
 #### Request
 
-```js
+```ts
 undefined;
 ```
 
 #### Response
 
-```js
+```ts
 {
   currentBlockIdentifier: {
     index: string;

--- a/content/documentation/rpc/chain/get_consensus_parameters.mdx
+++ b/content/documentation/rpc/chain/get_consensus_parameters.mdx
@@ -7,13 +7,13 @@ Gets consensus parameters from the chain
 
 #### Request
 
-```js
+```ts
 undefined;
 ```
 
 #### Response
 
-```js
+```ts
 {
   allowedBlockFuturesSeconds: number;
   genesisSupplyInIron: number;

--- a/content/documentation/rpc/chain/get_difficulty.mdx
+++ b/content/documentation/rpc/chain/get_difficulty.mdx
@@ -9,7 +9,7 @@ If no sequence is provided, the head will be used
 
 #### Request
 
-```js
+```ts
 {
   sequence?: number | null
 } | undefined
@@ -18,7 +18,7 @@ If no sequence is provided, the head will be used
 
 #### Response
 
-```js
+```ts
 {
   sequence: number;
   hash: string;

--- a/content/documentation/rpc/chain/get_network_hash_power.mdx
+++ b/content/documentation/rpc/chain/get_network_hash_power.mdx
@@ -9,7 +9,7 @@ If no blocks are provided, the last 120 blocks will be used. If no sequence is p
 
 #### Request
 
-```js
+```ts
 {
   blocks?: number | null
   sequence?: number | null
@@ -18,7 +18,7 @@ If no blocks are provided, the last 120 blocks will be used. If no sequence is p
 
 #### Response
 
-```js
+```ts
 {
   hashesPerSecond: number;
   blocks: number;

--- a/content/documentation/rpc/chain/get_network_info.mdx
+++ b/content/documentation/rpc/chain/get_network_info.mdx
@@ -7,13 +7,13 @@ Gets information about the node's network
 
 #### Request
 
-```js
+```ts
 undefined;
 ```
 
 #### Response
 
-```js
+```ts
 {
   networkId: number;
 }

--- a/content/documentation/rpc/chain/get_note_witness.mdx
+++ b/content/documentation/rpc/chain/get_note_witness.mdx
@@ -17,7 +17,7 @@ moves to a fork, this witness will no longer be usable in a transaction.
 
 #### Request
 
-```js
+```ts
 {
   index: number;
   confirmations?: number;
@@ -26,7 +26,7 @@ moves to a fork, this witness will no longer be usable in a transaction.
 
 #### Response
 
-```js
+```ts
 {
   treeSize: number
   rootHash: string

--- a/content/documentation/rpc/chain/get_transaction.mdx
+++ b/content/documentation/rpc/chain/get_transaction.mdx
@@ -7,7 +7,7 @@ Gets a transaction from a block hash and transaction hash
 
 #### Request
 
-```js
+```ts
 {
   blockHash: string;
   transactionHash: string;
@@ -16,7 +16,7 @@ Gets a transaction from a block hash and transaction hash
 
 #### Response
 
-```js
+```ts
 RpcTransaction & {
   noteSize: number
   blockHash: string

--- a/content/documentation/rpc/chain/get_transaction_stream.mdx
+++ b/content/documentation/rpc/chain/get_transaction_stream.mdx
@@ -7,7 +7,7 @@ Streams transactions from a head sequence given an incoming view key
 
 #### Request
 
-```js
+```ts
 {
   incomingViewKey: string
   head?: string | null
@@ -16,7 +16,7 @@ Streams transactions from a head sequence given an incoming view key
 
 #### Response
 
-```js
+```ts
 {
   type: 'connected' | 'disconnected' | 'fork'
   head: {
@@ -29,7 +29,7 @@ Streams transactions from a head sequence given an incoming view key
 
 Sub Objects: 
 
-```js
+```ts
 interface Note {
   assetId: string
   /**

--- a/content/documentation/rpc/chain/show_chain.mdx
+++ b/content/documentation/rpc/chain/show_chain.mdx
@@ -9,7 +9,7 @@ If stop and stop values are provided, only the blocks between the start and stop
 
 #### Request
 
-```js
+```ts
 {
   start?: number | null
   stop?: number | null
@@ -18,7 +18,7 @@ If stop and stop values are provided, only the blocks between the start and stop
 
 #### Response
 
-```js
+```ts
 {
   content: string[]
 }

--- a/content/documentation/rpc/config/get_config.mdx
+++ b/content/documentation/rpc/config/get_config.mdx
@@ -9,7 +9,7 @@ If the user flag is provided, a value will only be returned if the user set the 
 
 #### Request
 
-```js
+```ts
 {
   user?: boolean
   name?: string
@@ -18,7 +18,7 @@ If the user flag is provided, a value will only be returned if the user set the 
 
 #### Response
 
-```js
+```ts
 Partial<
   {
     blockGraffiti: string

--- a/content/documentation/rpc/config/set_config.mdx
+++ b/content/documentation/rpc/config/set_config.mdx
@@ -7,7 +7,7 @@ Sets a configuration value for the node
 
 #### Request
 
-```js
+```ts
 {
   name: string;
   value: unknown;
@@ -16,7 +16,7 @@ Sets a configuration value for the node
 
 #### Response
 
-```js
+```ts
 undefined;
 ```
 

--- a/content/documentation/rpc/config/unset_config.mdx
+++ b/content/documentation/rpc/config/unset_config.mdx
@@ -7,7 +7,7 @@ Unsets a configuration value for the node and falls back to the default.
 
 #### Request
 
-```js
+```ts
 {
   name: string;
 }
@@ -15,7 +15,7 @@ Unsets a configuration value for the node and falls back to the default.
 
 #### Response
 
-```js
+```ts
 undefined;
 ```
 

--- a/content/documentation/rpc/config/upload_config.mdx
+++ b/content/documentation/rpc/config/upload_config.mdx
@@ -8,7 +8,7 @@ This resets any previously set config options to their default values.
 
 #### Request
 
-```js
+```ts
 {
   config: Record<string, unknown>
 }
@@ -16,7 +16,7 @@ This resets any previously set config options to their default values.
 
 #### Response
 
-```js
+```ts
 undefined;
 ```
 

--- a/content/documentation/rpc/event/on_gossip.mdx
+++ b/content/documentation/rpc/event/on_gossip.mdx
@@ -7,13 +7,13 @@ Streams block headers on gossip events
 
 #### Request Body
 
-```js
+```ts
 undefined
 ```
 
 #### Response
 
-```js
+```ts
 { 
   blockHeader: RpcBlockHeader 
 }

--- a/content/documentation/rpc/event/on_reorganize_chain.mdx
+++ b/content/documentation/rpc/event/on_reorganize_chain.mdx
@@ -9,13 +9,13 @@ reorg, and `fork` is the header for the block at which the two forks diverged.
 
 #### Request Body
 
-```js
+```ts
 undefined
 ```
 
 #### Response
 
-```js
+```ts
 {
   oldHead: RpcBlockHeader
   newHead: RpcBlockHeader

--- a/content/documentation/rpc/event/on_transaction_gossip.mdx
+++ b/content/documentation/rpc/event/on_transaction_gossip.mdx
@@ -7,13 +7,13 @@ Streams serialized transactions on gossip events
 
 #### Request Body
 
-```js
+```ts
 undefined
 ```
 
 #### Response
 
-```js
+```ts
 {
   serializedTransaction: string
   valid: boolean

--- a/content/documentation/rpc/faucet/get_funds.mdx
+++ b/content/documentation/rpc/faucet/get_funds.mdx
@@ -11,7 +11,7 @@ If an account is not provided, the default account on the node will be used.
 
 #### Request
 
-```js
+```ts
 {
   account?: string
   email?: string
@@ -20,7 +20,7 @@ If an account is not provided, the default account on the node will be used.
 
 #### Response
 
-```js
+```ts
 {
   id: string;
 }

--- a/content/documentation/rpc/mempool/accept_transaction.mdx
+++ b/content/documentation/rpc/mempool/accept_transaction.mdx
@@ -7,7 +7,7 @@ Accepts a transaction into the mempool.
 
 #### Request Body
 
-```js
+```ts
 {
   transaction?: string
 }
@@ -15,7 +15,7 @@ Accepts a transaction into the mempool.
 
 #### Response
 
-```js
+```ts
 {
   accepted: boolean
   reason?: string

--- a/content/documentation/rpc/mempool/get_status.mdx
+++ b/content/documentation/rpc/mempool/get_status.mdx
@@ -7,7 +7,7 @@ Gets (and optionally streams) the status of the mempool
 
 #### Request Body
 
-```js
+```ts
 {
   stream?: boolean
 } | undefined
@@ -15,7 +15,7 @@ Gets (and optionally streams) the status of the mempool
 
 #### Response
 
-```js
+```ts
 {
   size: number
   sizeBytes: number

--- a/content/documentation/rpc/mempool/get_transactions.mdx
+++ b/content/documentation/rpc/mempool/get_transactions.mdx
@@ -10,7 +10,7 @@ For example, `feeRate={min: 30; max:60}` specifies that only transactions with `
 
 #### Request Body
 
-```js
+```ts
 {
   limit?: number
   feeRate?: {
@@ -38,7 +38,7 @@ For example, `feeRate={min: 30; max:60}` specifies that only transactions with `
 
 #### Response
 
-```js
+```ts
 {
   serializedTransaction: string
   position: number

--- a/content/documentation/rpc/miner/block_template_stream.mdx
+++ b/content/documentation/rpc/miner/block_template_stream.mdx
@@ -7,13 +7,13 @@ Streams block templates from the chain for mining blocks
 
 #### Request
 
-```js
+```ts
 undefined;
 ```
 
 #### Response
 
-```js
+```ts
 {
   header: {
     sequence: number

--- a/content/documentation/rpc/miner/submit_block.mdx
+++ b/content/documentation/rpc/miner/submit_block.mdx
@@ -7,7 +7,7 @@ Submit a block template to the mining manager
 
 #### Request
 
-```js
+```ts
 {
   header: {
     sequence: number
@@ -29,7 +29,7 @@ Submit a block template to the mining manager
 
 #### Response
 
-```js
+```ts
 {
   added: boolean
   reason:

--- a/content/documentation/rpc/node/get_log_stream.mdx
+++ b/content/documentation/rpc/node/get_log_stream.mdx
@@ -7,13 +7,13 @@ Streams logs from the node
 
 #### Request Body
 
-```js
+```ts
 undefined
 ```
 
 #### Response
 
-```js
+```ts
 {
   level: string
   type: string

--- a/content/documentation/rpc/node/get_status.mdx
+++ b/content/documentation/rpc/node/get_status.mdx
@@ -7,7 +7,7 @@ Gets (and optionally streams) the node's status
 
 #### Request Body
 
-```js
+```ts
 {
   stream?: boolean
 } | undefined
@@ -15,7 +15,7 @@ Gets (and optionally streams) the node's status
 
 #### Response
 
-```js
+```ts
 {
   node: {
     status: 'started' | 'stopped' | 'error'

--- a/content/documentation/rpc/node/stop_node.mdx
+++ b/content/documentation/rpc/node/stop_node.mdx
@@ -7,13 +7,13 @@ Shuts the node down
 
 #### Request Body
 
-```js
+```ts
 undefined
 ```
 
 #### Response
 
-```js
+```ts
 undefined
 ```
 

--- a/content/documentation/rpc/peer/add_peer.mdx
+++ b/content/documentation/rpc/peer/add_peer.mdx
@@ -7,7 +7,7 @@ Attempts to connect to a peer through WebSockets using the given host and port. 
 
 #### Request
 
-```js
+```ts
 {
   host: string
   port?: number
@@ -17,7 +17,7 @@ Attempts to connect to a peer through WebSockets using the given host and port. 
 
 #### Response
 
-```js
+```ts
 {
   added: boolean
 }

--- a/content/documentation/rpc/peer/get_banned_peers.mdx
+++ b/content/documentation/rpc/peer/get_banned_peers.mdx
@@ -7,7 +7,7 @@ Gets (and optionally streams) banned peers from the node's peer network
 
 #### Request
 
-```js
+```ts
 {
   stream?: boolean
 }
@@ -15,7 +15,7 @@ Gets (and optionally streams) banned peers from the node's peer network
 
 #### Response
 
-```js
+```ts
 {
   peers: Array<{
     identity: string

--- a/content/documentation/rpc/peer/get_peer.mdx
+++ b/content/documentation/rpc/peer/get_peer.mdx
@@ -7,7 +7,7 @@ Gets (and optionally streams) peer data from an identity
 
 #### Request
 
-```js
+```ts
 {
   identity: string
   stream?: boolean
@@ -16,7 +16,7 @@ Gets (and optionally streams) peer data from an identity
 
 #### Response
 
-```js
+```ts
 {
   peer: RpcPeerResponse | null
 }

--- a/content/documentation/rpc/peer/get_peer_messages.mdx
+++ b/content/documentation/rpc/peer/get_peer_messages.mdx
@@ -7,7 +7,7 @@ Gets (and optionally streams) peer messages from an identity
 
 #### Request
 
-```js
+```ts
 {
   identity: string
   stream?: boolean
@@ -16,7 +16,7 @@ Gets (and optionally streams) peer messages from an identity
 
 #### Response
 
-```js
+```ts
 {
   brokeringPeerDisplayName?: string
   direction: 'send' | 'receive'

--- a/content/documentation/rpc/peer/get_peers.mdx
+++ b/content/documentation/rpc/peer/get_peers.mdx
@@ -7,7 +7,7 @@ Gets (and optionally streams) peers from the node's peer network
 
 #### Request
 
-```js
+```ts
 {
   stream?: boolean
 } | undefined
@@ -15,7 +15,7 @@ Gets (and optionally streams) peers from the node's peer network
 
 #### Response
 
-```js
+```ts
 {
   peers: RpcPeerResponse[]
 }

--- a/content/documentation/rpc/rpc/get_status.mdx
+++ b/content/documentation/rpc/rpc/get_status.mdx
@@ -7,7 +7,7 @@ Gets (and optionally streams) the status of the RPC server
 
 #### Request
 
-```js
+```ts
 {
   stream?: boolean
 } | undefined
@@ -15,7 +15,7 @@ Gets (and optionally streams) the status of the RPC server
 
 #### Response
 
-```js
+```ts
 {
   started: boolean
   adapters: Array<{

--- a/content/documentation/rpc/wallet/add_transaction.mdx
+++ b/content/documentation/rpc/wallet/add_transaction.mdx
@@ -9,7 +9,7 @@ Returns the names of the wallet accounts involved in the transaction.
 
 #### Request
 
-```js
+```ts
 {
   transaction: string
   broadcast?: boolean
@@ -18,7 +18,7 @@ Returns the names of the wallet accounts involved in the transaction.
 
 #### Response
 
-```js
+```ts
 {
   accounts: string[]
   hash: string

--- a/content/documentation/rpc/wallet/burn_asset.mdx
+++ b/content/documentation/rpc/wallet/burn_asset.mdx
@@ -7,7 +7,7 @@ Creates a transaction burning a custom asset from a given account, posts the tra
 
 #### Request
 
-```js
+```ts
 {
   account?: string
   assetId: string
@@ -22,7 +22,7 @@ Creates a transaction burning a custom asset from a given account, posts the tra
 
 #### Response
 
-```js
+```ts
 RpcBurn & {
   asset: RpcAsset
   transaction: RpcWalletTransaction

--- a/content/documentation/rpc/wallet/create.mdx
+++ b/content/documentation/rpc/wallet/create.mdx
@@ -11,7 +11,7 @@ Creates a new account in the wallet with the given name and optionally sets it a
 
 #### Request
 
-```js
+```ts
 {
   name: string
   default?: boolean
@@ -20,7 +20,7 @@ Creates a new account in the wallet with the given name and optionally sets it a
 
 #### Response
 
-```js
+```ts
 {
   name: string;
   publicAddress: string;

--- a/content/documentation/rpc/wallet/createAccount.mdx
+++ b/content/documentation/rpc/wallet/createAccount.mdx
@@ -7,7 +7,7 @@ Creates a new account in the wallet with the given name and optionally sets it a
 
 #### Request
 
-```js
+```ts
 {
   name: string
   default?: boolean
@@ -16,7 +16,7 @@ Creates a new account in the wallet with the given name and optionally sets it a
 
 #### Response
 
-```js
+```ts
 {
   name: string;
   publicAddress: string;

--- a/content/documentation/rpc/wallet/create_transaction.mdx
+++ b/content/documentation/rpc/wallet/create_transaction.mdx
@@ -11,7 +11,7 @@ Creating a raw transaction does not require a spend key. They are not added to t
 
 #### Request
 
-```js
+```ts
 {
   account?: string
   outputs: {
@@ -42,7 +42,7 @@ Creating a raw transaction does not require a spend key. They are not added to t
 
 #### Response
 
-```js
+```ts
 {
   transaction: string;
 }

--- a/content/documentation/rpc/wallet/estimate_fee_rates.mdx
+++ b/content/documentation/rpc/wallet/estimate_fee_rates.mdx
@@ -9,13 +9,13 @@ See `chain/estimateFeeRate` to see how fee rates are estimated.
 
 #### Request
 
-```js
+```ts
 undefined;
 ```
 
 #### Response
 
-```js
+```ts
 {
   slow: string;
   average: string;

--- a/content/documentation/rpc/wallet/export_account.mdx
+++ b/content/documentation/rpc/wallet/export_account.mdx
@@ -9,7 +9,7 @@ The `spendingKey` will be null in the response if `viewOnly = true` or if export
 
 #### Request
 
-```js
+```ts
 {
   account?: string
   viewOnly?: boolean
@@ -25,7 +25,7 @@ The `spendingKey` will be null in the response if `viewOnly = true` or if export
 
 If no format is specified, the legacy `RpcAccountImport` type will be returned. Otherwise, the RPC will serialize the account into a string of the desired format.
 
-```js
+```ts
 {
   account: string | RpcAccountImport | null
 }

--- a/content/documentation/rpc/wallet/get_account_notes_stream.mdx
+++ b/content/documentation/rpc/wallet/get_account_notes_stream.mdx
@@ -7,7 +7,7 @@ Streams the notes in the given account. If the account is not specified, the def
 
 #### Request
 
-```js
+```ts
 {
   account?: string
 }
@@ -15,7 +15,7 @@ Streams the notes in the given account. If the account is not specified, the def
 
 #### Response
 
-```js
+```ts
 RpcWalletNote
 ```
 

--- a/content/documentation/rpc/wallet/get_account_transaction.mdx
+++ b/content/documentation/rpc/wallet/get_account_transaction.mdx
@@ -7,7 +7,7 @@ Gets a transaction for an account. If the account is not specified, the default 
 
 #### Request
 
-```js
+```ts
 {
   hash: string
   account?: string
@@ -17,7 +17,7 @@ Gets a transaction for an account. If the account is not specified, the default 
 
 #### Response
 
-```js
+```ts
 {
   account: string
   transaction: RpcWalletTransaction | null

--- a/content/documentation/rpc/wallet/get_account_transactions.mdx
+++ b/content/documentation/rpc/wallet/get_account_transactions.mdx
@@ -7,7 +7,7 @@ Gets transactions for the given account. If not specified, the default account i
 
 #### Request
 
-```js
+```ts
 {
   account?: string
   hash?: string
@@ -20,7 +20,7 @@ Gets transactions for the given account. If not specified, the default account i
 
 #### Response
 
-```js
+```ts
 RpcWalletTransaction
 ```
 

--- a/content/documentation/rpc/wallet/get_accounts.mdx
+++ b/content/documentation/rpc/wallet/get_accounts.mdx
@@ -7,7 +7,7 @@ Gets the names of the accounts in the wallet.
 
 #### Request
 
-```js
+```ts
 {
   default?: boolean
   displayName?: boolean
@@ -16,7 +16,7 @@ Gets the names of the accounts in the wallet.
 
 #### Response
 
-```js
+```ts
 {
   accounts: string[]
 }

--- a/content/documentation/rpc/wallet/get_accounts_status.mdx
+++ b/content/documentation/rpc/wallet/get_accounts_status.mdx
@@ -7,7 +7,7 @@ Gets the status of an account. If not specified, the status of all accounts are 
 
 #### Request
 
-```js
+```ts
 {
   account?: string
 }
@@ -15,7 +15,7 @@ Gets the status of an account. If not specified, the status of all accounts are 
 
 #### Response
 
-```js
+```ts
 {
   accounts: Array<{
     name: string

--- a/content/documentation/rpc/wallet/get_asset.mdx
+++ b/content/documentation/rpc/wallet/get_asset.mdx
@@ -7,7 +7,7 @@ Gets an asset from the wallet from a given identifier and account
 
 #### Request
 
-```js
+```ts
 {
   account?: string
   confirmations?: number
@@ -17,7 +17,7 @@ Gets an asset from the wallet from a given identifier and account
 
 #### Response
 
-```js
+```ts
 RpcAsset
 ```
 

--- a/content/documentation/rpc/wallet/get_assets.mdx
+++ b/content/documentation/rpc/wallet/get_assets.mdx
@@ -7,7 +7,7 @@ Streams all the assets in the wallet of the given account. If not specified, the
 
 #### Request
 
-```js
+```ts
 {
   account?: string
   confirmations?: number
@@ -16,7 +16,7 @@ Streams all the assets in the wallet of the given account. If not specified, the
 
 #### Response
 
-```js
+```ts
 RpcAsset
 ```
 

--- a/content/documentation/rpc/wallet/get_balance.mdx
+++ b/content/documentation/rpc/wallet/get_balance.mdx
@@ -8,7 +8,7 @@ the default account will be used. If the asset is not specified, `$IRON` will be
 
 #### Request
 
-```js
+```ts
 {
   account?: string
   assetId?: string
@@ -18,7 +18,7 @@ the default account will be used. If the asset is not specified, `$IRON` will be
 
 #### Response
 
-```js
+```ts
 {
   account: string
   assetId: string

--- a/content/documentation/rpc/wallet/get_balances.mdx
+++ b/content/documentation/rpc/wallet/get_balances.mdx
@@ -7,7 +7,7 @@ Gets the wallet's `$IRON` balance, as well as balances of custom assets of the g
 
 #### Request
 
-```js
+```ts
 {
   account?: string
   confirmations?: number
@@ -16,7 +16,7 @@ Gets the wallet's `$IRON` balance, as well as balances of custom assets of the g
 
 #### Response
 
-```js
+```ts
 {
   account: string
   balances: {

--- a/content/documentation/rpc/wallet/get_default_account.mdx
+++ b/content/documentation/rpc/wallet/get_default_account.mdx
@@ -7,13 +7,13 @@ Gets the default account of the wallet.
 
 #### Request
 
-```js
+```ts
 { } | undefined
 ```
 
 #### Response
 
-```js
+```ts
 {
   account: {
     name: string

--- a/content/documentation/rpc/wallet/get_node_status.mdx
+++ b/content/documentation/rpc/wallet/get_node_status.mdx
@@ -7,7 +7,7 @@ Gets (and optionally streams) the status of node that the wallet is connected to
 
 #### Request Body
 
-```js
+```ts
 {
   stream?: boolean
 } | undefined
@@ -15,7 +15,7 @@ Gets (and optionally streams) the status of node that the wallet is connected to
 
 #### Response
 
-```js
+```ts
 {
   node: {
     status: 'started' | 'stopped' | 'error'

--- a/content/documentation/rpc/wallet/get_notes.mdx
+++ b/content/documentation/rpc/wallet/get_notes.mdx
@@ -11,7 +11,7 @@ Supports filtering notes by any of the fields in the `filter` request parameter.
 
 #### Types 
 
-```js
+```ts
 type StringMinMax = {
   min?: string
   max?: string
@@ -32,7 +32,7 @@ type GetNotesRequestFilter = {
 
 #### Request
 
-```js
+```ts
 {
   account?: string
   pageSize?: number
@@ -43,7 +43,7 @@ type GetNotesRequestFilter = {
 
 #### Response
 
-```js
+```ts
 {
   notes: Array<RpcWalletNote>
   nextPageCursor: string | null

--- a/content/documentation/rpc/wallet/get_public_key.mdx
+++ b/content/documentation/rpc/wallet/get_public_key.mdx
@@ -7,7 +7,7 @@ Gets the public key of the given account. If the account is not specified, the d
 
 #### Request
 
-```js
+```ts
 {
   account?: string
 }
@@ -15,7 +15,7 @@ Gets the public key of the given account. If the account is not specified, the d
 
 #### Response
 
-```js
+```ts
 {
   account: string;
   publicKey: string;

--- a/content/documentation/rpc/wallet/import_account.mdx
+++ b/content/documentation/rpc/wallet/import_account.mdx
@@ -9,7 +9,7 @@ This endpoint also supports structured input.
 
 #### Request
 
-```js
+```ts
 {
   account: RpcAccountImport | string
   name?: string
@@ -22,7 +22,7 @@ Rpc Objects:
 
 #### Response
 
-```js
+```ts
 {
   name: string;
   isDefaultAccount: boolean;

--- a/content/documentation/rpc/wallet/mint_asset.mdx
+++ b/content/documentation/rpc/wallet/mint_asset.mdx
@@ -7,7 +7,7 @@ Creates a transaction minting a custom asset from a given account, posts the tra
 
 #### Request
 
-```js
+```ts
 {
   account?: string
   fee?: string
@@ -25,7 +25,7 @@ Creates a transaction minting a custom asset from a given account, posts the tra
 
 #### Response
 
-```js
+```ts
 RpcMint & {
   asset: RpcAsset
   transaction: RpcWalletTransaction

--- a/content/documentation/rpc/wallet/post_transaction.mdx
+++ b/content/documentation/rpc/wallet/post_transaction.mdx
@@ -7,7 +7,7 @@ Posts a transaction and submits it to the wallet, mempool, and network if possib
 
 #### Request
 
-```js
+```ts
 {
   account?: string
   transaction: string
@@ -17,7 +17,7 @@ Posts a transaction and submits it to the wallet, mempool, and network if possib
 
 #### Response
 
-```js
+```ts
 {
   transaction: string;
 }

--- a/content/documentation/rpc/wallet/remove.mdx
+++ b/content/documentation/rpc/wallet/remove.mdx
@@ -9,7 +9,7 @@ Removes an account from the wallet.
 
 #### Request
 
-```js
+```ts
 {
   account: string
   confirm?: boolean
@@ -19,7 +19,7 @@ Removes an account from the wallet.
 
 #### Response
 
-```js
+```ts
 {
   needsConfirm?: boolean
 }

--- a/content/documentation/rpc/wallet/removeAccount.mdx
+++ b/content/documentation/rpc/wallet/removeAccount.mdx
@@ -7,7 +7,7 @@ Removes an account from the wallet.
 
 #### Request
 
-```js
+```ts
 {
   account: string
   confirm?: boolean
@@ -17,7 +17,7 @@ Removes an account from the wallet.
 
 #### Response
 
-```js
+```ts
 {
   needsConfirm?: boolean
 }

--- a/content/documentation/rpc/wallet/rename.mdx
+++ b/content/documentation/rpc/wallet/rename.mdx
@@ -9,7 +9,7 @@ Changes the name of an account in the wallet.
 
 #### Request
 
-```js
+```ts
 {
   account: string
   newName: string
@@ -18,7 +18,7 @@ Changes the name of an account in the wallet.
 
 #### Response
 
-```js
+```ts
 undefined
 ```
 

--- a/content/documentation/rpc/wallet/renameAccount.mdx
+++ b/content/documentation/rpc/wallet/renameAccount.mdx
@@ -7,7 +7,7 @@ Changes the name of an account in the wallet.
 
 #### Request
 
-```js
+```ts
 {
   account: string
   newName: string
@@ -16,7 +16,7 @@ Changes the name of an account in the wallet.
 
 #### Response
 
-```js
+```ts
 undefined
 ```
 

--- a/content/documentation/rpc/wallet/rescan_account.mdx
+++ b/content/documentation/rpc/wallet/rescan_account.mdx
@@ -7,7 +7,7 @@ Rescans an account in the wallet and updates the balance and available notes.
 
 #### Request
 
-```js
+```ts
 {
   follow?: boolean
   from?: number
@@ -16,7 +16,7 @@ Rescans an account in the wallet and updates the balance and available notes.
 
 #### Response
 
-```js
+```ts
 {
   sequence: number;
   startedAt: number;

--- a/content/documentation/rpc/wallet/send_transaction.mdx
+++ b/content/documentation/rpc/wallet/send_transaction.mdx
@@ -7,7 +7,7 @@ Creates a transaction, posts the transaction, and submits it to the wallet, memp
 
 #### Request
 
-```js
+```ts
 {
   account?: string
   outputs: {
@@ -26,7 +26,7 @@ Creates a transaction, posts the transaction, and submits it to the wallet, memp
 
 #### Response
 
-```js
+```ts
 {
   account: string;
   hash: string;

--- a/content/documentation/rpc/wallet/use_account.mdx
+++ b/content/documentation/rpc/wallet/use_account.mdx
@@ -7,7 +7,7 @@ Sets an account as the default account of the wallet.
 
 #### Request
 
-```js
+```ts
 {
   account: string;
 }
@@ -15,7 +15,7 @@ Sets an account as the default account of the wallet.
 
 #### Response
 
-```js
+```ts
 undefined;
 ```
 

--- a/content/documentation/rpc/worker/get_status.mdx
+++ b/content/documentation/rpc/worker/get_status.mdx
@@ -8,7 +8,7 @@ The workers operate similar to a threadpool.
 
 #### Request
 
-```js
+```ts
 {
   stream?: boolean
 } | undefined
@@ -16,7 +16,7 @@ The workers operate similar to a threadpool.
 
 #### Response
 
-```js
+```ts
 {
   started: boolean
   workers: number


### PR DESCRIPTION
### What changed?

Format responses for Typescript instead of javascript 

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
