### PR TITLE
Update docs for removing explorer url config values

### DIFF
--- a/content/documentation/rpc/config/get_config.mdx
+++ b/content/documentation/rpc/config/get_config.mdx
@@ -37,8 +37,6 @@ Partial<
     enableRpcTls: boolean
     enableSyncing: boolean
     enableTelemetry: boolean
-    explorerBlocksUrl: string
-    explorerTransactionsUrl: string
     feeEstimatorMaxBlockHistory: number
     feeEstimatorPercentileAverage: number
     feeEstimatorPercentileFast: number


### PR DESCRIPTION
### What changed?
Removing config values related to https://github.com/iron-fish/ironfish/pull/4510
- 

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
