### PR TITLE
Update Node App links to point to 2.0 Node App

### DIFF
--- a/components/NodeApp/Download/Download.tsx
+++ b/components/NodeApp/Download/Download.tsx
@@ -14,6 +14,7 @@ import {
   DownloadUrlsByPlatform,
   PLATFORM_LABELS,
   Platform,
+  REPO_URL,
 } from "@/utils/nodeAppUrl/getNodeAppUrlByPlatform";
 import { useDownloadLinkForPlatform } from "@/utils/nodeAppUrl/useDownloadLinkForPlatform";
 import { useMemo } from "react";
@@ -23,7 +24,6 @@ type Props = {
   downloadUrlsByPlatform?: DownloadUrlsByPlatform;
 };
 
-const REPO_URL = "https://github.com/iron-fish/node-app";
 const DOWNLOAD_OPTIONS_TARGET = "download-options";
 
 const DownloadButton = forwardRef<ButtonProps, "a">((props, ref) => (

--- a/components/SearchField/SearchField.tsx
+++ b/components/SearchField/SearchField.tsx
@@ -7,7 +7,13 @@ export function SearchField() {
 
   return (
     <>
-      <SearchInput as="button" onClick={onOpen} />
+      <SearchInput
+        as="button"
+        onClick={onOpen}
+        _placeholder={{
+          color: "#7F7F7F",
+        }}
+      />
       <SearchModal isOpen={isOpen} onClose={onClose} />
     </>
   );

--- a/layouts/Documentation/Documentation.tsx
+++ b/layouts/Documentation/Documentation.tsx
@@ -95,10 +95,7 @@ export function DocumentationLayout({
         <Box
           as="article"
           maxW="container.lg"
-          py={{
-            base: 8,
-            md: 24,
-          }}
+          py={8}
           pb={40}
           px={8}
           mx="auto"
@@ -107,7 +104,13 @@ export function DocumentationLayout({
           ref={contentRef}
         >
           <HStack justifyContent="flex-end">
-            <Box w="100%" maxW="250px">
+            <Box
+              w="100%"
+              maxW={{
+                base: "100%",
+                sm: "250px",
+              }}
+            >
               <SearchField />
             </Box>
           </HStack>

--- a/pages/use/node-app/index.tsx
+++ b/pages/use/node-app/index.tsx
@@ -27,6 +27,7 @@ type Props = {
 
 export default function NodeApp({ downloadUrlsByPlatform }: Props) {
   const isClient = useIsClient();
+  console.log({ downloadUrlsByPlatform });
   return (
     <>
       <Head>

--- a/utils/nodeAppUrl/getNodeAppUrlByPlatform.ts
+++ b/utils/nodeAppUrl/getNodeAppUrlByPlatform.ts
@@ -1,7 +1,9 @@
 import { isArray, isObject } from "lodash-es";
 
+export const REPO_URL = "https://github.com/iron-fish/ironfish-node-app";
+
 const ENDPOINT =
-  "https://api.github.com/repos/iron-fish/node-app/releases/latest";
+  "https://api.github.com/repos/iron-fish/ironfish-node-app/releases/latest";
 
 export const PLATFORMS = {
   WINDOWS: "windows",
@@ -52,7 +54,7 @@ function getDownloadUrlsByPlatform(data: unknown) {
       downloadUrlsByPlatform.windows = url;
     } else if (url.endsWith("arm64.dmg")) {
       downloadUrlsByPlatform["mac-arm"] = url;
-    } else if (url.endsWith("x64.dmg")) {
+    } else if (url.endsWith(".dmg")) {
       downloadUrlsByPlatform["mac-intel"] = url;
     }
   }


### PR DESCRIPTION
### What changed?

- Updates Node App links to point to Node App 2.0
- Small search bar design tweak

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
