### PR TITLE
updating docs to reflect public key length update

### DIFF
--- a/content/get-started/cli-cmd-wallet-create.mdx
+++ b/content/get-started/cli-cmd-wallet-create.mdx
@@ -16,7 +16,7 @@ Enter the name of the account: MyNewAccount
 Creating account MyNewAccount
 
 Account MyNewAccount created with public address
-6a085865ac5608c8ec64189db54d4b5c085da9da12dad0a0bf00f60e52c16b0303d8a8dd7d82601f577c8d
+2494643f9b40ab60063e18da483c5a67f65ae2e39fd12e78cf38c4740830ec33
 
 Run "ironfish wallet:use MyNewAccount" to set the account as default
   `}


### PR DESCRIPTION
### What changed?

A long time ago (few months before mainnet) the Iron Fish key construction had a diversifier. We removed the diversifier which caused the key length to shorten but it looks like not all the documentation was updated to reflect that change. 