### PR TITLE
Fix custom route not matching root

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,7 +13,7 @@ const nextConfig = {
   async headers() {
     return [
       {
-        source: "/(.*)",
+        source: "/:path*{/}?",
         headers: [
           {
             key: "X-Frame-Options",


### PR DESCRIPTION
### What changed?

As described in this bug here https://github.com/vercel/next.js/issues/14930