### PR TITLE
Make XFrameOptions consistent with frame-ancestors

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,7 +17,7 @@ const nextConfig = {
         headers: [
           {
             key: "X-Frame-Options",
-            value: "SAMEORIGIN",
+            value: "DENY",
           },
           {
             key: "Content-Security-Policy",


### PR DESCRIPTION
### What changed?

We have frame-ancestors as none which is the same as deny. This just makes them the same.
