### PR TITLE
Standardize note formatting

### DIFF
--- a/content/documentation/rpc/faucet/get_funds.mdx
+++ b/content/documentation/rpc/faucet/get_funds.mdx
@@ -3,7 +3,7 @@ title: faucet/getFunds
 description: RPC Faucet | Iron Fish Documentation
 ---
 
-**THIS ENDPOINT IS ONLY AVAILABLE ON TESTNET**
+> **Note:** This endpoint only works when using Testnet
 
 Submits a request to get funds from the faucet for an account.
 


### PR DESCRIPTION
### What changed?

Found this inconsistent formatting and copied this from the faucet command documentation.