### PR TITLE
feat(website): Add `wallet/getUnsignedTransactionNotes`

### DIFF
--- a/content/documentation/rpc/objects/rpcUnsignedTransactionNote.mdx
+++ b/content/documentation/rpc/objects/rpcUnsignedTransactionNote.mdx
@@ -1,0 +1,17 @@
+---
+title: RpcUnsignedTransactionNote
+description: RpcUnsignedTransactionNote | Iron Fish Documentation
+---
+```typescript
+export type RpcUnsignedTransactionNote = {
+  assetId: string
+  memo: string
+  noteHash: string
+  owner: string
+  sender: string
+  value: string
+}
+```
+
+Usage: 
+- [wallet/getUnsignedTransactionNotes](/developers/documentation/rpc/wallet/get_unsigned_transaction_notes)

--- a/content/documentation/rpc/wallet/get_unsigned_transaction_notes.mdx
+++ b/content/documentation/rpc/wallet/get_unsigned_transaction_notes.mdx
@@ -1,0 +1,30 @@
+---
+title: wallet/getUnsignedTransactionNotes
+description: RPC Wallet | Iron Fish Documentation
+---
+
+Retrieves sent and received notes from an unsigned transaction's outputs for a given account. If the account is not specified, the default account will be used.
+
+#### Request
+
+```ts
+{
+  account?: string
+  unsignedTransaction: string
+}
+```
+
+#### Response
+
+```ts
+{
+  receivedNotes: RpcUnsignedTransactionNote[]
+  sentNotes: RpcUnsignedTransactionNote[]
+}
+```
+
+RPC Objects: 
+- [RpcUnsignedTransactionNote](/developers/documentation/rpc/objects/rpcUnsignedTransactionNote)
+
+
+###### [View on Github](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/getUnsignedTransactionNotes.ts)

--- a/content/documentation/sidebar.ts
+++ b/content/documentation/sidebar.ts
@@ -371,6 +371,10 @@ export const sidebar: SidebarDefinition = [
             label: "getNodeStatus",
           },
           {
+            id: "rpc/wallet/get_unsigned_transaction_notes",
+            label: "getUnsignedTransactionNotes",
+          },
+          {
             id: "rpc/wallet/get_notes",
             label: "getNotes",
           },


### PR DESCRIPTION
### What changed?

- Adds documentation for fetching decrypted merkle notes from unsigned transaction's ouputs

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
