### PR TITLE
create signature share docs

### DIFF
--- a/content/documentation/rpc/wallet/multisig/create_signature_share.mdx
+++ b/content/documentation/rpc/wallet/multisig/create_signature_share.mdx
@@ -3,7 +3,7 @@ title: wallet/multisig/createSignatureShare
 description: RPC Multisig | Iron Fish Documentation
 ---
 
-Creates a signature share for a participant for a given signing package. After this step, the signatures are collected and used by the [wallet/multisig/aggregateSignatureShares](/developers/documentation/rpc/wallet/multisig/aggregate_signature_shares) to create the final signed transaction.
+Creates a signature share for a participant for a given signing package. After this step, the signatures are collected and used by the [wallet/multisig/aggregateSignatureShares](/developers/documentation/rpc/wallet/multisig/aggregate_signature_shares) RPC to create the final signed transaction.
 
 #### Request
 

--- a/content/documentation/rpc/wallet/multisig/create_signature_share.mdx
+++ b/content/documentation/rpc/wallet/multisig/create_signature_share.mdx
@@ -1,0 +1,25 @@
+---
+title: wallet/multisig/createSignatureShare
+description: RPC Multisig | Iron Fish Documentation
+---
+
+Creates a signature share for a participant for a given signing package. These signatures are then collected and used by the [wallet/multisig/aggregateSignatureShares](/developers/documentation/rpc/wallet/multisig/aggregate_signature_shares) to create the final signed transaction.
+
+#### Request
+
+```ts
+{
+  account?: string
+  signingPackage: string
+}
+```
+
+#### Response
+
+```ts
+{
+  signatureShare: string
+}
+```
+
+###### [View on Github](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/multisig/createSignatureShare.ts)

--- a/content/documentation/rpc/wallet/multisig/create_signature_share.mdx
+++ b/content/documentation/rpc/wallet/multisig/create_signature_share.mdx
@@ -3,7 +3,7 @@ title: wallet/multisig/createSignatureShare
 description: RPC Multisig | Iron Fish Documentation
 ---
 
-Creates a signature share for a participant for a given signing package. These signatures are then collected and used by the [wallet/multisig/aggregateSignatureShares](/developers/documentation/rpc/wallet/multisig/aggregate_signature_shares) to create the final signed transaction.
+Creates a signature share for a participant for a given signing package. After this step, the signatures are collected and used by the [wallet/multisig/aggregateSignatureShares](/developers/documentation/rpc/wallet/multisig/aggregate_signature_shares) to create the final signed transaction.
 
 #### Request
 

--- a/content/documentation/sidebar.ts
+++ b/content/documentation/sidebar.ts
@@ -309,6 +309,10 @@ export const sidebar: SidebarDefinition = [
                 id: "rpc/wallet/multisig/create_participant",
                 label: "createParticipant",
               },
+              {
+                id: "rpc/wallet/multisig/create_signature_share",
+                label: "createSignatureShare",
+              },
             ],
           },
           {


### PR DESCRIPTION
### What changed?

- create signature share docs

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
