### PR TITLE
documents wallet:multisig:participant

### DIFF
--- a/content/get-started/cli-cmd-wallet-multisig-participant-get.mdx
+++ b/content/get-started/cli-cmd-wallet-multisig-participant-get.mdx
@@ -1,0 +1,26 @@
+---
+title: wallet:multisig:participant
+seo: Wallet Multisig Participant Get Command
+---
+
+# Usage
+
+Retrieve a multisig participant identity by name
+
+```sh
+ironfish wallet:multisig:participant
+```
+
+<Terminal command="ironfish wallet:multisig:participant -n participant-1"
+  output={`
+Identity
+72709fc4f310aab17dc1e7e470e96f90d69ea477910744d2ca47341ff6a0860b217ec2181aa55fb6a38072dfd8976c6306ef41336afef58c8e049df3f9669ca73614eff096e13b1f2fc7f16c686eec04ea3e9b92785eca7993b83458ba04a1023ef4cdc9126b07cd5ad864c2d32d9cda575869be9c5192c37e5410465cb1fbed0f
+  `}
+/>
+
+# Flags
+
+| Flag | Description |
+| ---- | ----------- |
+| `-n, --name` | Name of the participant identity (required) |
+

--- a/content/get-started/sidebar.ts
+++ b/content/get-started/sidebar.ts
@@ -61,6 +61,7 @@ export const sidebar: SidebarDefinition = [
             label: "multisig",
             items: [
               "cli-cmd-wallet-multisig-participant-create",
+              "cli-cmd-wallet-multisig-participant-get",
               "cli-cmd-wallet-multisig-commitment-create",
               "cli-cmd-wallet-multisig-commitment-aggregate",
               "cli-cmd-wallet-multisig-signature-create",


### PR DESCRIPTION
### What changed?

adds documentation for command to retrieve a participant identity

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
