### PR TITLE
Add port to mining pool

### DIFF
--- a/content/documentation/integration_mining.mdx
+++ b/content/documentation/integration_mining.mdx
@@ -56,7 +56,7 @@ And use that public key to join the mining pool:
 
 
 ```sh
-ironfish miners:start --pool testnet.pool.ironfish.network --address <PUBLIC KEY>
+ironfish miners:start --pool testnet.pool.ironfish.network:9034 --address <PUBLIC KEY>
 ```
 
 [Join our Discord](https://discord.ironfish.network) if you're interested in creating a different pool for Iron Fish.


### PR DESCRIPTION
### What changed?

Sometimes I've needed to look up the testnet pool and the port it runs on, so I thought it'd be easier to put it here explicitly rather than using the default port from the config.

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
