### PR TITLE
documents automatic inclusion of account as signer

### DIFF
--- a/content/documentation/rpc/wallet/multisig/create_signing_commitment.mdx
+++ b/content/documentation/rpc/wallet/multisig/create_signing_commitment.mdx
@@ -23,4 +23,6 @@ Creates the siging commitment for a participant of a multisig wallet. The partic
 }
 ```
 
+> **Note**: the identity for the `account` parameter (or the default account if no account is specified) is automatically included in the list of signer identities.
+
 ###### [View on Github](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/multisig/createSigningCommitment.ts)

--- a/content/get-started/cli-cmd-wallet-multisig-commitment-create.mdx
+++ b/content/get-started/cli-cmd-wallet-multisig-commitment-create.mdx
@@ -5,7 +5,8 @@ seo: Wallet Multisig Commitment Create command
 
 # Usage
 
-Creates a signing commitment from a multisig signer account (participant) for a given transaction
+Creates a signing commitment from a multisig signer account (participant) for a given transaction and a list of signers. The identity for the account that creates the signing commitment is included in the list of signers automatically.
+
 
 ```sh
 ironfish wallet:multisig:commitment:create


### PR DESCRIPTION
### What changed?

when creating a signing commitment we will automatically include the identity for the account creating the commitment in the list of signers

updates documentation for cli and rpc to reflect this


---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
