### PR TITLE
Keeps sidebar menu items closed by default.

### DIFF
--- a/lib/ui/src/components/SidebarMenu/SidebarMenu.tsx
+++ b/lib/ui/src/components/SidebarMenu/SidebarMenu.tsx
@@ -1,24 +1,24 @@
-import NextLink from "next/link";
-import { ReactNode } from "react";
 import {
-  Link,
-  Box,
-  Text,
-  VStack,
   Accordion,
-  AccordionItem,
   AccordionButton,
-  AccordionPanel,
   AccordionIcon,
-  useBreakpointValue,
-  useDisclosure,
+  AccordionItem,
+  AccordionPanel,
+  Box,
   Collapse,
   HStack,
+  Link,
+  Text,
+  VStack,
+  useBreakpointValue,
+  useDisclosure,
 } from "@chakra-ui/react";
+import NextLink from "next/link";
+import { NextRouter, useRouter } from "next/router";
+import { ReactNode } from "react";
 import { GiHamburgerMenu } from "react-icons/gi";
 import { IoMdClose } from "react-icons/io";
 import { useIsClient } from "usehooks-ts";
-import { NextRouter, useRouter } from "next/router";
 import { NAV_HEIGHT } from "../NavBar/NavBar";
 
 export type SidebarItem = {
@@ -123,7 +123,7 @@ function createNestedMenuItems(
     return (
       <Accordion
         key={item.title}
-        defaultIndex={0}
+        defaultIndex={isAccordionItemSelected ? 0 : -1}
         allowToggle
         border="none"
         w="100%"


### PR DESCRIPTION
Makes navigating the menu items more intuitive since you're going top to bottom.

### What changed?

Before: 

![image](https://github.com/iron-fish/website/assets/13268167/7fdfaa7e-f904-43b8-b8cb-4b37ba6cf306)

After: 
![image](https://github.com/iron-fish/website/assets/13268167/30273516-6647-402b-b150-48ad8dbcb480)

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
