### PR TITLE
updates multisig documentation with path flag

### DIFF
--- a/content/get-started/cli-cmd-wallet-multisig-commitment-aggregate.mdx
+++ b/content/get-started/cli-cmd-wallet-multisig-commitment-aggregate.mdx
@@ -33,3 +33,20 @@ f100000000c3d2051e0257eb8aaee9aa...9844a3e90873a5a5808e83417c336105
 | `-c, --commitment | Signing commitment from participant (may be specified multiple times) ||
 | `-f, --account` | The account to use for generating the commitment, must be a multisig participant account | The wallet's default account is used |
 | `-u, --unsignedTransaction` | The serialized unsigned transaction that needs to be signed ||
+| `--path` | Path to a JSON file containing unsigned transaction and commitments ||
+
+# Multisig Transaction JSON
+
+You can use the `--path` flag and a JSON file like the example shown below to pass an unsigned transaction and list of commitments to this command:
+
+```json
+{
+  "commitment": [
+    "723f415e10ec47955036105834ab7dcc...342022941ff351bd60723b9a9aa2d29a",
+    "721cb9582cec837588df0b08d77d4870...abc27377671c68323af864b57b718380"
+  ],
+  "unsignedTransaction": "01010000000000000002000000000000...9f3fb432907a84c8483586a6a565d308"
+}
+```
+
+Note that the JSON file can contain other fields, like `identity`, so you can use the same file throughout the multisig signing flow.

--- a/content/get-started/cli-cmd-wallet-multisig-commitment-create.mdx
+++ b/content/get-started/cli-cmd-wallet-multisig-commitment-create.mdx
@@ -59,3 +59,21 @@ The signing commitment will be valid only if all participant identities specifie
 | `-i, --identity` | The identity of the participants that will sign the transaction (may be specified multiple times to add multiple signers) ||
 | `-u, --unsignedTransaction` | The serialized unsigned transaction that needs to be signed ||
 | `--confirm` | Create signing commitment without confirming transaction details ||
+| `--path` | Path to a JSON file containing participant identities ||
+
+# Multisig Transaction JSON
+
+You can use the `--path` flag and a JSON file like the example shown below to pass a list of identities and an unsigned transaction to this command:
+
+```json
+{
+  "identity": [
+    "723f415e10ec47955036105834ab7dcc...89557882a9d3834e9ee9a82dc4ac2f0a",
+    "721cb9582cec837588df0b08d77d4870...2b269850be9d80d1f8360fa57df0a306"
+  ],
+  "unsignedTransaction": "01010000000000000002000000000000...9f3fb432907a84c8483586a6a565d308"
+}
+```
+
+Note that the JSON file can contain other fields, like `commitment`, so you can use the same file throughout the multisig signing flow.
+

--- a/content/get-started/cli-cmd-wallet-multisig-signature-aggregate.mdx
+++ b/content/get-started/cli-cmd-wallet-multisig-signature-aggregate.mdx
@@ -34,3 +34,22 @@ Fee: $IRON 0.00000001
 | `-p, --signingPackage` | The signing package (unsigned transaction and commitments) for which the signature will be created ||
 | `-s, --signatureShare` | Participant signature share (may be specified multiple times) ||
 | `--[no]-broadcast` | Broadcast the transaction to the network after signing ||
+| `--path` | Path to a JSON file containing participant identities ||
+
+# Multisig Transaction JSON
+
+You can use the `--path` flag and a JSON file like the example shown below to pass a signing package and list of signature shares to this command:
+
+```json
+{
+  "signatureShare": [
+    "723f415e10ec47955036105834ab7dcc...be94dd1ae640f3fcf8bddb9478a0cb02",
+    "721cb9582cec837588df0b08d77d4870...ad47e9f3ba751c77ec7530708d1d2b07"
+  ],
+  "signingPackage": "f100000000c3d2051e0257eb8aaee9aa...9844a3e90873a5a5808e83417c336105"
+}
+```
+
+Note that the JSON file can contain other fields, like `commitment`, so you can use the same file throughout the multisig signing flow.
+
+

--- a/content/get-started/cli-cmd-wallet-multisig-signature-create.mdx
+++ b/content/get-started/cli-cmd-wallet-multisig-signature-create.mdx
@@ -52,3 +52,19 @@ Signature share:
 | `-f, --account` | The account to use for generating the signature share, must be a multisig participant account | The wallet's default account is used |
 | `-s, --signingPackage` | The signing package (unsigned transaction and commitments) for which the signature will be created ||
 | `--confirm` | Create signature share without confirming transaction details ||
+| `--path` | Path to a JSON file containing participant identities ||
+
+# Multisig Transaction JSON
+
+You can use the `--path` flag and a JSON file like the example shown below to pass a signing package to this command:
+
+```json
+{
+  "signingPackage": "f100000000c3d2051e0257eb8aaee9aa...9844a3e90873a5a5808e83417c336105"
+}
+```
+
+Note that the JSON file can contain other fields, like `commitment`, so you can use the same file throughout the multisig signing flow.
+
+
+

--- a/content/get-started/multisig-signing.mdx
+++ b/content/get-started/multisig-signing.mdx
@@ -144,3 +144,28 @@ Fee: $IRON 0.00000001
 />
  
 The signature aggregation command broadcasts the signed transaction to the network by default. If the transaction is not broadcast, use the `ironfish wallet:transaction:add` command to braodcast it to the network.
+
+# Multisig Transaction JSON
+
+Each of the commands in steps 3 through 6, above, accepts a `--path` flag that should refer to a JSON file with any of the fields below:
+
+```json
+{
+  "identity": [
+    "723f415e10ec47955036105834ab7dcc...89557882a9d3834e9ee9a82dc4ac2f0a",
+    "721cb9582cec837588df0b08d77d4870...2b269850be9d80d1f8360fa57df0a306"
+  ],
+  "unsignedTransaction": "01010000000000000002000000000000...9f3fb432907a84c8483586a6a565d308",
+  "commitment": [
+    "723f415e10ec47955036105834ab7dcc...342022941ff351bd60723b9a9aa2d29a",
+    "721cb9582cec837588df0b08d77d4870...abc27377671c68323af864b57b718380"
+  ],
+  "signingPackage": "f100000000c3d2051e0257eb8aaee9aa...9844a3e90873a5a5808e83417c336105",
+  "signatureShare": [
+    "723f415e10ec47955036105834ab7dcc...be94dd1ae640f3fcf8bddb9478a0cb02",
+    "721cb9582cec837588df0b08d77d4870...ad47e9f3ba751c77ec7530708d1d2b07"
+  ]
+}
+```
+
+Users can use the same file throughout the signing process by updating the multisig transaction JSON file with new commitments or signature shares as these are created and passing the file to the next command in the process.


### PR DESCRIPTION
### What changed?

adds path flag to each command page that accepts it

explain multisig transaction JSON files on each page and add explanation to the signing overview page

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
