### PR TITLE
removes id from RpcAccountImport

### DIFF
--- a/content/documentation/rpc/objects/rpcAccountImport.mdx
+++ b/content/documentation/rpc/objects/rpcAccountImport.mdx
@@ -4,7 +4,6 @@ description: RpcAccountImport | Iron Fish Documentation
 ---
 ```typescript
 export type RpcAccountImport = {
-  id: string
   version: number
   name: string
   viewKey: string


### PR DESCRIPTION
### What changed?

- `id` is not included/required in the RpcAccountImport object

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
