### PR TITLE
Add asset metadata fields to RPC responses

### DIFF
--- a/content/documentation/rpc/objects/rpcAsset.mdx
+++ b/content/documentation/rpc/objects/rpcAsset.mdx
@@ -13,6 +13,10 @@ export type RpcAsset = {
   createdTransactionHash: string
   verification: AssetVerification
   supply?: string
+  symbol?: string,
+  decimals?: number,
+  logoURI?: string,
+  website?: string,
   /**
    * @deprecated query for the transaction to find it's status
    */


### PR DESCRIPTION
### What changed?
Adding asset metadata fields to RPC responses

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
