### PR TITLE
add documentation for dkg/round2 RPC

### DIFF
--- a/content/documentation/rpc/wallet/multisig/dkg/round2.mdx
+++ b/content/documentation/rpc/wallet/multisig/dkg/round2.mdx
@@ -1,0 +1,27 @@
+---
+title: wallet/multisig/dkg/round2
+description: RPC Multisig DKG Round2| Iron Fish Documentation
+---
+
+Performs Round 2 of the Distributed Key Generation (DKG) protocol for multisig account generation.
+
+#### Request
+
+```ts
+{
+  secretName: string
+  encryptedSecretPackage: string
+  publicPackages: Array<string>
+}
+```
+
+#### Response
+
+```ts
+{
+  encryptedSecretPackage: string
+  publicPackages: Array<{ recipientIdentity: string; publicPackage: string }>
+}
+```
+
+###### [View on Github](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/rpc/routes/wallet/multisig/dkg/round2.ts)

--- a/content/documentation/sidebar.ts
+++ b/content/documentation/sidebar.ts
@@ -339,6 +339,10 @@ export const sidebar: SidebarDefinition = [
                     id: "rpc/wallet/multisig/dkg/round1",
                     label: "round1",
                   },
+                  {
+                    id: "rpc/wallet/multisig/dkg/round2",
+                    label: "round2",
+                  },
                 ],
               },
             ],


### PR DESCRIPTION
### What changed?

- adds round2 RPC doc page
- adds round2 to sidebar


---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
