### PR TITLE
Fix link of multisig blog post

### DIFF
--- a/content/blog/2024-04-09-multi-sig.mdx
+++ b/content/blog/2024-04-09-multi-sig.mdx
@@ -90,5 +90,5 @@ The multisig feature will be expanded to include Distributed Key Generation (DKG
 
 As the cryptocurrency ecosystem continues to evolve, embracing innovative solutions like multisignature transactions is crucial to fortifying the foundations of security and trust. Whether for individuals, businesses, or financial institutions, the adoption of multisignature technology heralds a new era of secure and transparent financial transactions in the digital age.
 
-You can start using multisignature transactions by updating `ironfish` to `v2.1.0`. We have uploaded a [recipe](https://ironfish.network/developers/documentation/recipes_multisig_create_account) on how to get started and updated our [CLI documentation](https://ironfish.network/use/get-started/multisig-creation) with all the available multisig commands.
+You can start using multisignature transactions by updating `ironfish` to `v2.1.0`. We have uploaded a [recipe](https://ironfish.network/developers/documentation/recipes_multisig_create_account) on how to get started and updated our [CLI documentation](https://ironfish.network/use/get-started/multisig-creation-tdk) with all the available multisig commands.
 


### PR DESCRIPTION
### What changed?

One documentation page got renamed; fixing the blog link.