### PR TITLE
Redirect multisig-creation -> multisig-creation-tdk

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -166,6 +166,11 @@ upgrade-insecure-requests;
         destination: "/developers/documentation/rpc/node/get_log_stream",
         permanent: true,
       },
+      {
+        source: "/use/get-started/multisig-creation",
+        destination: "/use/get-started/multisig-creation-tdk",
+        permanent: true,
+      },
     ];
   },
 };


### PR DESCRIPTION
### What changed?

`multisig-creation` was renamed to `multisig-creation-tdk` in b05d56f743d493f05df96a2d7e126ac865e793dd. Setting up a redirect so that people who archieved the old link do not get disrupted.