### PR TITLE
Default  and update docs to mention env vars

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_ORIGIN="http://localhost:3000"

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env*.local
+.env.local
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -1,38 +1,24 @@
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 
-## Getting Started
+## Quick Start
 
-First, run the development server:
+1. Clone repo
+  - `git clone git@github.com:iron-fish/website.git`
+2. Install dependencies
+  - `yarn install`
+3. Start the development server
+  - `yarn dev`
+4. Open [http://localhost:3000](http://localhost:3000) with your browser to see the site
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-```
+## Environment Variables
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+To set up local environment variables, rename the `.env.local.example` file to `.env.local` and fill in the necessary values.
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+If you are adding new environment variables, make sure to add them to the `.env.local.example` file as well. If you are adding sensitive information, just make the value in the example file an empty string.
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
-
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
-
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
-
-## Learn More
+## About Next.js
 
 To learn more about Next.js, take a look at the following resources:
 
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.

--- a/layouts/Blog/Blog.tsx
+++ b/layouts/Blog/Blog.tsx
@@ -38,7 +38,9 @@ export function BlogLayout({
   seoTitlePostfix = "",
 }: Props) {
   const fullTitle = seoTitlePrefix + (seoTitle || title) + seoTitlePostfix;
-  const imageUrl = image && new URL(image, process.env.NEXT_PUBLIC_ORIGIN);
+  const imageUrl =
+    image &&
+    new URL(image, process.env.NEXT_PUBLIC_ORIGIN || "http://localhost:3000");
   return (
     <>
       <Head>


### PR DESCRIPTION
### What changed?

- Defaults NEXT_PUBLIC_ORIGIN locally
- Cleans up docs a bit, and adds info about .env.local file

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
