### PR TITLE
Fall back to showing both downloads if architecture detection fails

### DIFF
--- a/components/NodeApp/Download/Download.tsx
+++ b/components/NodeApp/Download/Download.tsx
@@ -47,21 +47,67 @@ export function DownloadForCurrentPlatform({ downloadUrlsByPlatform }: Props) {
         },
       ];
 
-    return linkData.map(({ url, label }) => {
-      return url && label
-        ? { href: url, children: "Download Now" }
+    return linkData.map(({ url, label, platform }) => {
+      if (url && label && platform) {
+        if (linkData.length === 1) {
+          return { href: url, children: "Download Now" };
+        }
+
+        const downloadButtonLabel: string = (() => {
+          switch (platform) {
+            case "mac-arm": {
+              return "Apple Silicon";
+            }
+            case "mac-intel": {
+              return "Intel";
+            }
+            case "windows": {
+              return "Windows";
+            }
+          }
+        })();
+
+        return {
+          href: url,
+          children:
+            linkData.length === 1
+              ? "Download Now"
+              : `Download for ${downloadButtonLabel}`,
+        };
+      }
+      if (!url || !label || !platform)
+        return { href: REPO_URL, children: "View on GitHub", target: "_blank" };
+
+      return url && label && platform
+        ? {
+            href: url,
+            children:
+              linkData.length === 1
+                ? "Download Now"
+                : `Download for ${platform}`,
+          }
         : { href: REPO_URL, children: "View on GitHub", target: "_blank" };
     });
   }, [linkData]);
 
   return (
     <Flex direction="column" alignItems="center" maxW="100%">
-      <Flex direction="row" gap={4}>
+      <Flex
+        direction="row"
+        gap={4}
+        flexWrap="wrap"
+        justifyContent="center"
+        mb={linkProps.length > 1 ? 8 : 0}
+      >
         {linkProps.map((lp, i) => (
           <Flex direction="column" alignItems="center" key={i}>
-            <DownloadButton as="a" size="lg" mb={4} {...lp} />
-            <Text>{linkData && linkData[i].label}</Text>
-            <Box my={3} w="120px" borderBottom="1px dashed black" />
+            <DownloadButton as="a" size="lg" {...lp} />
+            {linkProps.length === 1 && (
+              <>
+                <Text mt={4}>{linkData && linkData[i].label}</Text>
+                <Box my={3} w="120px" borderBottom="1px dashed black" />
+              </>
+            )}
           </Flex>
         ))}
       </Flex>

--- a/components/NodeApp/Download/Download.tsx
+++ b/components/NodeApp/Download/Download.tsx
@@ -41,26 +41,30 @@ export function DownloadForCurrentPlatform({ downloadUrlsByPlatform }: Props) {
 
   const linkProps = useMemo(() => {
     if (!linkData)
-      return {
-        opacity: 0,
-      };
+      return [
+        {
+          opacity: 0,
+        },
+      ];
 
-    const { url, label } = linkData;
-
-    return url && label
-      ? { href: url, children: "Download Now" }
-      : { href: REPO_URL, children: "View on GitHub", target: "_blank" };
+    return linkData.map(({ url, label }) => {
+      return url && label
+        ? { href: url, children: "Download Now" }
+        : { href: REPO_URL, children: "View on GitHub", target: "_blank" };
+    });
   }, [linkData]);
 
   return (
     <Flex direction="column" alignItems="center" maxW="100%">
-      <DownloadButton as="a" size="lg" mb={4} {...linkProps} />
-      {linkData?.label && (
-        <>
-          <Text>{linkData.label}</Text>
-          <Box my={3} w="120px" borderBottom="1px dashed black" />
-        </>
-      )}
+      <Flex direction="row" gap={4}>
+        {linkProps.map((lp, i) => (
+          <Flex direction="column" alignItems="center" key={i}>
+            <DownloadButton as="a" size="lg" mb={4} {...lp} />
+            <Text>{linkData && linkData[i].label}</Text>
+            <Box my={3} w="120px" borderBottom="1px dashed black" />
+          </Flex>
+        ))}
+      </Flex>
       {downloadUrlsByPlatform && (
         <Text
           as="a"

--- a/utils/nodeAppUrl/useDownloadLinkForPlatform.ts
+++ b/utils/nodeAppUrl/useDownloadLinkForPlatform.ts
@@ -10,11 +10,14 @@ import { UAParser } from "ua-parser-js";
 export function useDownloadLinkForPlatform(
   downloadUrlsByPlatform?: DownloadUrlsByPlatform
 ) {
-  const [platformData, setPlatformData] = useState<{
-    url: string | null;
-    label: string | null;
-    platform: Platform | null;
-  } | null>(null);
+  const [platformData, setPlatformData] = useState<
+    | {
+        url: string | null;
+        label: string | null;
+        platform: Platform | null;
+      }[]
+    | null
+  >(null);
 
   useEffect(() => {
     const run = async () => {
@@ -40,7 +43,7 @@ async function getDataForPlatform(
   };
 
   if (!downloadUrlsByPlatform) {
-    return notFoundOption;
+    return [notFoundOption];
   }
 
   if (ua.os.name === "Mac OS") {
@@ -60,26 +63,49 @@ async function getDataForPlatform(
       }
     } catch (err) {}
 
-    return architecture === "arm"
-      ? {
+    if (architecture === "arm") {
+      return [
+        {
           platform: PLATFORMS.MAC_ARM,
           label: "macOS (Apple Silicon)",
           url: downloadUrlsByPlatform[PLATFORMS.MAC_ARM],
-        }
-      : {
+        },
+      ];
+    }
+
+    if (architecture === "x86") {
+      return [
+        {
           platform: PLATFORMS.MAC_INTEL,
           label: "macOS (Intel)",
           url: downloadUrlsByPlatform[PLATFORMS.MAC_INTEL],
-        };
+        },
+      ];
+    }
+
+    return [
+      {
+        platform: PLATFORMS.MAC_ARM,
+        label: "macOS (Apple Silicon)",
+        url: downloadUrlsByPlatform[PLATFORMS.MAC_ARM],
+      },
+      {
+        platform: PLATFORMS.MAC_INTEL,
+        label: "macOS (Intel)",
+        url: downloadUrlsByPlatform[PLATFORMS.MAC_INTEL],
+      },
+    ];
   }
 
   if (ua.os.name === "Windows") {
-    return {
-      platform: PLATFORMS.WINDOWS,
-      label: "Windows",
-      url: downloadUrlsByPlatform[PLATFORMS.WINDOWS],
-    };
+    return [
+      {
+        platform: PLATFORMS.WINDOWS,
+        label: "Windows",
+        url: downloadUrlsByPlatform[PLATFORMS.WINDOWS],
+      },
+    ];
   }
 
-  return notFoundOption;
+  return [notFoundOption];
 }


### PR DESCRIPTION
### What changed?

Changes the node app download page to show both architectures on mac if we're not able to detect your CPU architecture.

* [x] On Chrome Apple Silicon, should show only Apple Silicon
* [x] On Chrome Intel, should show only Intel
* [x] On Safari Mac, should show both

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
