### PR TITLE
Docs improvements

### DIFF
--- a/content/documentation/contribute/lint_and_format.mdx
+++ b/content/documentation/contribute/lint_and_format.mdx
@@ -18,5 +18,5 @@ This one is useful for writing code in our Rust files:
 
 Once these are installed, you can turn on "Format on Save" in the settings so you never have to worry about it again. Plus, they can warn you while you're writing code, to help find common issues before you even run the code. This can be found under `Preferences -> Settings -> Format On Save` (You can search for "format" in the search bar in the settings page to find it easily.)
 
-You can also enable the "Problems" tab to see the highlighted issues and suggestions easier. This can be found under `View -> Problems`.
+You can also enable the "Problems" tab to see the highlighted issues and suggestions more easily. This can be found under `View -> Problems`.
 

--- a/content/documentation/integration_deposits.mdx
+++ b/content/documentation/integration_deposits.mdx
@@ -33,6 +33,6 @@ async function main(): Promise<void> {
 ```
 
 It's recommended to configure confirmations to be greater than 0 if you'd like
-confidence that a block has been confirmed with low probability of a
+confidence that a block has been confirmed with a low probability of a
 reorganization. The default value used in Iron Fish is 2, but you can increase
 this value for higher confidence.

--- a/content/documentation/integration_keys.mdx
+++ b/content/documentation/integration_keys.mdx
@@ -3,7 +3,7 @@ title: Managing Keys
 description: Integration Guide | Managing Keys | Iron Fish Documentation
 ---
 
-Iron Fish keys are pieces of data which can be used to encrypt and decrypt data.
+Iron Fish keys are pieces of data that can be used to encrypt and decrypt data.
 A [wallet](/use/get-started/glossary#Wallet) is a collection of many accounts,
 and an account holds private [keys](/use/get-started/glossary#Keys) which enable users to view transaction details
 and transfer assets to other

--- a/content/documentation/integration_mining.mdx
+++ b/content/documentation/integration_mining.mdx
@@ -67,7 +67,7 @@ ironfish miners:start --pool testnet.pool.ironfish.network:9034 --address <PUBLI
 - Difficulty (and therefore time to mine a block) can change depending on how fast blocks are mined on the Iron Fish network.
 - Make sure you are correctly connected to the Iron Fish network (you should see `Connected to the Iron Fish network` in your node logs).
 
-#### Not connected to a node - waiting 5s before retrying
+#### Not connected to a node - waiting for 5s before retrying
 Make sure that your node is currently running. If you are using a different `datadir` argument to start your node, make sure to use it as well when starting the miner. For example:
 
 

--- a/content/documentation/integration_rpc.mdx
+++ b/content/documentation/integration_rpc.mdx
@@ -13,7 +13,7 @@ Refer to our [RPC docs](/developers/documentation/rpc/chain/broadcast_transactio
 
 ## JavaScript SDK
 
-Currently Iron Fish only supports a JavaScript SDK. An example interaction to
+Currently Iron Fish only supports a JavaScript SDK. An example of interaction to
 fetch your account's public address looks like:
 
 ```js

--- a/content/documentation/rpc/chain/get_consensus_parameters.mdx
+++ b/content/documentation/rpc/chain/get_consensus_parameters.mdx
@@ -52,7 +52,7 @@ undefined;
   enableAssetOwnership: number | null
 
   /**
-   * Before upgrade we have block timestamp smaller than previous block. After this
+   * Before upgrade we have block timestamp smaller than the previous block. After this
    * block we enforce the block timestamps in the sequential order as the block sequences.
    */
   enforceSequentialBlockTime: number | null


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.