### PR TITLE
Turns the upgrade-insecure-requests directive off in development mode

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,8 @@ const nextConfig = {
     },
   },
   async headers() {
+    const isDev = process.env.NEXT_PUBLIC_ORIGIN !== 'https://ironfish.network/';
+
     return [
       {
         source: "/:path*",
@@ -31,7 +33,7 @@ object-src 'none';
 base-uri 'self';
 form-action 'self';
 frame-ancestors 'none';
-upgrade-insecure-requests;
+${isDev ? '' : 'upgrade-insecure-requests;'}
             `.replace(/\n/g, ""),
           },
         ],

--- a/next.config.js
+++ b/next.config.js
@@ -11,7 +11,7 @@ const nextConfig = {
     },
   },
   async headers() {
-    const isDev = process.env.NEXT_PUBLIC_ORIGIN !== 'https://ironfish.network/';
+    const isDev = process.env.NODE_ENV === "development"
 
     return [
       {


### PR DESCRIPTION
### What changed?

When this is on, safari forces an https connection to the server. This is not ideal for development as it requires a valid SSL certificate. This is turned off in development mode.

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
