### PR TITLE
Update to supported versions of GitHub Actions

### DIFF
--- a/.github/workflows/update-search-index.yml
+++ b/.github/workflows/update-search-index.yml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.head_ref }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '20'
 


### PR DESCRIPTION
### What changed?

Updating the GitHub actions used in the search index generation so they don't throw warnings. 

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
