### PR TITLE
Change workflow trigger to run after PR merge

### DIFF
--- a/.github/workflows/update-search-index.yml
+++ b/.github/workflows/update-search-index.yml
@@ -1,7 +1,7 @@
 name: Update Search Index
 
 on:
-  pull_request:
+  push:
     branches:
       - master
 
@@ -31,6 +31,13 @@ jobs:
         git config --global user.name 'github-actions[bot]'
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
+    - name: Skip Duplicate Actions
+      id: skip_check
+      uses: fkirc/skip-duplicate-actions@v5.3.1
+      with:
+        cancel_others: 'true'
+        concurrent_skipping: 'outdated_runs'
+
     - name: Extract Branch Name
       id: extract_branch
       shell: bash
@@ -38,6 +45,7 @@ jobs:
         echo "::set-output name=branch::${{ github.head_ref }}"
 
     - name: Commit and Push Search Index Updates
+      if: steps.skip_check.outputs.should_skip != 'true'  # Only run if not skipped
       run: |
         git add -A
         git commit -m "Update search index" || echo "No changes to commit"


### PR DESCRIPTION
Updated the GitHub Actions workflow to trigger the update search index job after a pull request is merged into the master branch. Previously, the job was triggered during the review process, which could lead to unnecessary updates and conflicts with upcoming changes. This change ensures that the search index is only updated with finalized changes, improving the reliability of the index.

Edit: 

Added the use of https://github.com/fkirc/skip-duplicate-actions 

If there are two merges to master than are done in quick succession, the older search index update is cancelled for the new one. 

Example of cancelled run https://github.com/iron-fish/website/actions/runs/11350073202 in favor of https://github.com/iron-fish/website/actions/runs/11350074259/job/31567660815