### PR TITLE
Disables lazy loading for backer images

### DIFF
--- a/components/HomePage/Backers/Backers.tsx
+++ b/components/HomePage/Backers/Backers.tsx
@@ -44,7 +44,7 @@ export function Backers() {
           ImgDragonfly,
         ].map((img, i) => (
           <Box key={i} mx={margin} filter="grayscale(1)">
-            <Image src={img} height={height} alt="" />
+            <Image src={img} height={height} alt="" loading="eager" />
           </Box>
         ))}
       </Marquee>


### PR DESCRIPTION
Backer images weren't loading for some mobile users - I was able to consistently reproduce on an iPhone 13 using iOS 16.0. I think it has to do with the version of iOS (or safari) and not the phone or screen size.

[slack conversation](https://iflabs.slack.com/archives/C02PT5MPRRC/p1731459486813069)