### PR TITLE
fixes documentation of mnemonic format in wallet/exportAccount

### DIFF
--- a/content/documentation/rpc/wallet/export_account.mdx
+++ b/content/documentation/rpc/wallet/export_account.mdx
@@ -21,7 +21,7 @@ The `spendingKey` will be null in the response if `viewOnly = true` or if export
 Supported [AccountFormats](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/wallet/account/encoder/encoder.ts#L27)
  - Base64Json: The full account and all keys as a JSON string then encoded in base64.
  - JSON: The full account and all keys as a JSON string
- - Mnemonic: The private key in 12 word format in the specified language
+ - Mnemonic: The private key encoded as 24 word BIP39 mnemonic phrase in the specified language
  - SpendingKey: The private key as a hex-encoded string.
 
 [Supported Mnemonic Languages](https://github.com/iron-fish/ironfish/blob/master/ironfish/src/utils/language.ts#L7)


### PR DESCRIPTION
### What changed?

- corrects length of phrase to 24 words

- mentions that it's BIP39

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
