### PR TITLE
Fix chainport link so dropdowns populate correctly

### DIFF
--- a/components/HomePage/Safety/Safety.tsx
+++ b/components/HomePage/Safety/Safety.tsx
@@ -180,7 +180,7 @@ export function Safety() {
             <ItemCard
               name={formatMessage(messages.chainPortBridge)}
               description={formatMessage(messages.chainPortBridgeDescription)}
-              href="https://app.chainport.io/?from=ETHEREUM&to=IRONFISH"
+              href="https://app.chainport.io/?from=ETHEREUM&token=USDC&to=IRONFISH&token=USDC"
               linkText={formatMessage(messages.chainPortBridgeLink)}
               imageSrc={chainportImage}
               imageContainerProps={{


### PR DESCRIPTION
### What changed?

- Fixes the Chainport URL so the dropdowns prepopulate correclty

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
