### PR TITLE
Website: removed seq and prev deprecated references for exportChainStream

### DIFF
--- a/content/documentation/rpc/chain/export_chain_stream.mdx
+++ b/content/documentation/rpc/chain/export_chain_stream.mdx
@@ -26,15 +26,7 @@ stop will be returned.
   block?: RpcBlockHeader & {
     main: boolean
     head: boolean
-    latest: boolean
-    /**
-     * @deprecated Please use sequence instead
-     */
-    seq: number
-    /**
-     * @deprecated Please use previousBlockHash instead
-     */
-    prev: string
+    latest: booleans
   }
 }
 ```

--- a/content/documentation/rpc/chain/export_chain_stream.mdx
+++ b/content/documentation/rpc/chain/export_chain_stream.mdx
@@ -26,7 +26,7 @@ stop will be returned.
   block?: RpcBlockHeader & {
     main: boolean
     head: boolean
-    latest: booleans
+    latest: boolean
   }
 }
 ```

--- a/content/documentation/rpc/objects/rpcBlockHeader.mdx
+++ b/content/documentation/rpc/objects/rpcBlockHeader.mdx
@@ -16,10 +16,6 @@ export type RpcBlockHeader = {
   graffiti: string
   work: string
   noteSize: number | null
-  /**
-   * @deprecated Please use previousBlockHash instead
-   */
-  previous: string
 }
 ```
 


### PR DESCRIPTION
### What changed?
Removed seq and prev for exportChainStream
- 

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
