### PR TITLE
getBalance: removed assetVerification

### DIFF
--- a/content/documentation/rpc/wallet/get_balance.mdx
+++ b/content/documentation/rpc/wallet/get_balance.mdx
@@ -31,13 +31,7 @@ the default account will be used. If the asset is not specified, `$IRON` will be
   availableNoteCount: number
   confirmations: number
   blockHash: string | null
-  sequence: number | null
-  /**
-   * @deprecated Please use getAsset endpoint to get this information
-   * */
-  assetVerification: {
-    status: 'verified' | 'unverified' | 'unknown'
-  }
+  sequence: number | null'
 }
 ```
 


### PR DESCRIPTION
### What changed?
 - removed assetVerification from getBalance 

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
