### PR TITLE
followChainStream: removed main key from block

### DIFF
--- a/content/documentation/rpc/chain/follow_chain_stream.mdx
+++ b/content/documentation/rpc/chain/follow_chain_stream.mdx
@@ -25,12 +25,7 @@ the head of the chain (true by default).
   head: {
     sequence: number
   }
-  block: RpcBlock & {
-    /**
-     * @deprecated this can be derived from the type
-     */
-    main: boolean
-  }
+  block: RpcBlock
 }
 ```
 


### PR DESCRIPTION
### What changed?
followChainStream: removed main key from block 
- 

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
