### PR TITLE
Fix broken link in mining.mdx issue #794

### DIFF
--- a/content/get-started/mining.mdx
+++ b/content/get-started/mining.mdx
@@ -24,7 +24,7 @@ Please check out the [ecosystem page](/use/ecosystem?category=mining-software) f
 
 ## Solo Mining
 
-The Iron Fish CLI also supports solo mining with most of the available mining software. After [installing](/developers/documentation/install-npm) the CLI, [start](http://localhost:3000/developers/documentation/run-a-node) your node and make sure it is synced before starting a local mining pool.
+The Iron Fish CLI also supports solo mining with most of the available mining software. After [installing](/developers/documentation/install-npm) the CLI, [start](/developers/documentation/run-a-node) your node and make sure it is synced before starting a local mining pool.
 
 To start a local mining pool on port 9034 by running the following command:
 


### PR DESCRIPTION
Remove "http://localhost:3000" from link, fix #794

### What changed?

This PR fixes a broken localhost link. The "start" now displays a link to the correct documentation page on the main site.
Closes #794 

---

<sub>**Reminder:** If content (docs, blogs, pages) is moved or renamed, please ensure there are no broken links.</sub>
